### PR TITLE
Removed old ocean-agent repo link, added some new repo links

### DIFF
--- a/doc/architecture/repos.md
+++ b/doc/architecture/repos.md
@@ -1,11 +1,10 @@
-This page is a central point for documenting the Ocean Github repositories in use
+# GitHub Repositories
 
-# Github repositories
+This page is a central point for documenting the Ocean GitHub repositories in use.
 
 ## Frontend
 
 * [Ocean Pleuston Frontend](https://github.com/oceanprotocol/pleuston/)
-
 
 ## Keeper
 
@@ -14,18 +13,18 @@ This page is a central point for documenting the Ocean Github repositories in us
 ## Provider
 
 * [Ocean Provider](https://github.com/oceanprotocol/provider)
-* [Ocean Agent](https://github.com/oceanprotocol/ocean-agent/)
 
 ## Libraries
 
 * [Ocean Squid JavaScript Library](https://github.com/oceanprotocol/squid-js)
 * [Ocean Squid Python Library](https://github.com/oceanprotocol/squid-py)
+* [Ocean Squid Java Library](https://github.com/oceanprotocol/squid-java)
 
 ### OceanDB
 
 The following projects implement the OceanDB Metadata plugins system:
 
 * [OceanDB Driver Interface](https://github.com/oceanprotocol/oceandb-driver-interface)
-* [OceanDB Bigchaindb Plugin](https://github.com/oceanprotocol/oceandb-bigchaindb-driver)
-* [OceanDB Mongodb Plugin](https://github.com/oceanprotocol/oceandb-mongodb-driver)
-
+* [OceanDB BigchainDB Plugin](https://github.com/oceanprotocol/oceandb-bigchaindb-driver)
+* [OceanDB MongoDB Plugin](https://github.com/oceanprotocol/oceandb-mongodb-driver)
+* [OceanDB Elasticsearch Plugin](https://github.com/oceanprotocol/oceandb-elasticsearch-driver)


### PR DESCRIPTION
## Description

- Removed the link to "Ocean Agent" (a repo that is now gone)
- Added links to the "Ocean Squid Java Library" and the "Ocean Elasticsearch Plugin"
- Did some other minor copy-editing

## Is this PR related with an open issue?

No.
