### PR TITLE
Add a page about the documentation strategy

### DIFF
--- a/doc/development.md
+++ b/doc/development.md
@@ -8,6 +8,7 @@ Table of Contents
          * [Python](#python)
          * [Javascript](#javascript)
          * [Solidity](#solidity)
+      * [Documentation Strategy](#documentation-strategy)
       * [Boards](#boards)
    * [Source Control Management](#source-control-management)
       * [Branching Model](#branching-model)
@@ -41,6 +42,10 @@ We use consistent code styles at Ocean Protocol and enforce them through various
 * [How to publish JavaScript projects as npm packages](development/libraries-npm.md)
 
 ### Solidity
+
+## Documentation Strategy
+
+See [the page about the documentation strategy](development/documentation-strategy.md).
 
 ## Boards
 

--- a/doc/development/documentation-strategy.md
+++ b/doc/development/documentation-strategy.md
@@ -1,0 +1,17 @@
+# Documentation Strategy
+
+## Principles
+
+* Keep documentation about the specifics of Software X (e.g. squid-py) in the same repository as the source code of Software X. That way, when changes are made to Software X, the corresponding documentation can be updated in the same pull request.
+* Try to have all the docs about Software X in one directory (e.g. `docs/`) of the Software X repository, not scattered around, so it's easy to find.
+* When writing documentation manually, use [GitHub-flavored Markdown](https://help.github.com/articles/about-writing-and-formatting-on-github/). In the future, we might add a requirement to add some simple YAML "front matter" at the top, such as:
+
+```yaml
+title: This is the Title in Title Case
+slug: title-for-urls
+---
+Markdown content begins here.
+```
+
+* All documentation source files will be pulled from their source repositories into one online documentation site. Markdown and HTML can be used easily.
+* It's _okay_ to auto-generate some documentation, such as API documentation. Just render it to Markdown or HTML _and include the rendered documentation in the repository_, so that it can be handled akin to manually-written documentation.


### PR DESCRIPTION
I added a page about the Ocean documentation strategy. It's not asking anyone to change how they're doing documentation (at least not yet). It just summarizes how documentation is getting created now, and how that can work with a forthcoming [single documentation site](https://github.com/oceanprotocol/docs) (work in progress).

@MarcusJones The Jupyter notebooks are a special case that don't fit into the strategy described here. I gather that the hope is to have those all online (hosted "live" somewhere), so we can link to them easily.

@eruizgar91 I believe this PR resolves #18 