### PR TITLE
Renamed Provider to Aquarius (but not yet in squid.md or the page about the secret store)

### DIFF
--- a/PROJECT_MAP.md
+++ b/PROJECT_MAP.md
@@ -1,48 +1,25 @@
-# Ocean project map
+# Ocean Project Map
 
 This page serves as a map to the current project boards, milestones, and related resources.
 
-Main Project boards:
+## Main Project Boards
+
 1. [Business board](https://github.com/oceanprotocol/ocean/projects/1)
 1. [Research board](https://github.com/oceanprotocol/ocean/projects/3)
 1. [Development board](https://github.com/oceanprotocol/ocean/projects/2)
 
 A complete description of the Ocean boards can be found in the [Boards section](doc/alm/boards.md).
 
-Subsequent versions can be found in the [Milestones section](https://github.com/oceanprotocol/ocean/milestones).
+## Milestones
 
-## Current development
-The current milestone is [Plankton - Tethys Alpha (v0.1)](https://github.com/oceanprotocol/ocean/milestone/1).
+See the [Milestones page](https://github.com/oceanprotocol/ocean/milestones).
 
-This milestone is based mainly on the user story in  Plankton [MVP-2](https://github.com/oceanprotocol/ocean/issues/39) and the [On-Chain Access Control](https://github.com/oceanprotocol/ocean/issues/9). 
+The current milestone is [Trilobite - Tethys Beta (v0.9)](https://github.com/oceanprotocol/ocean/milestone/2).
 
-Main ocean development repos:
-* [Keeper-Contracts](https://github.com/oceanprotocol/keeper-contracts)
-All of the Solidity smart contracts that implement the Keeper features.
-* [Plauston](https://github.com/oceanprotocol/plankton-frontend)
-A simple web browser UI implemented with JavaScript for interacting with the Ocean Network. Supports publishing and consuming data assets.
-* [Provider-Backend](https://github.com/oceanprotocol/provider-backend)
-Handles off-chain database asset storage and serves data asset consumption requests.
+## Main Ocean Development Repositories
 
+See [doc/architecture/repos.md](doc/architecture/repos.md)
 
-## Keeper Contracts (On-Chain)
-* Asset Registration (Asset ID and price)
-* Asset Purchase
-* Access Control (asset consumption authorization)
+## Ocean Architecture
 
-## Provider Backend (OceanDB, Assets Registry and Asset Consumption)
-* Asset Metadata
-* Asset Resolver
-* List/Search Assets
-* Serve access requests and use on-chain authorization before granting access
-* Support uploading data assets to store at provider end
-
-## Front-End
-* Search registered assets
-* Display list of registered assets
-* View asset metadata
-* Purchase asset
-* Download purchased asset
-* Publish data asset
-* Update asset metadata
-
+See [doc/architecture.md](doc/architecture.md)

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -1,6 +1,5 @@
 
 Table of Contents
-=================
 
    * [Table of Contents](#table-of-contents)
    * [Architecture](#architecture)
@@ -10,7 +9,7 @@ Table of Contents
             * [Data science Tools](#data-science-tools)
          * [Tier 2 - Protocol Layer](#tier-2---protocol-layer)
             * [Squid Libraries](#squid-libraries)
-            * [Provider](#provider)
+            * [Aquarius](#aquarius)
             * [Brizo](#brizo)
          * [Tier 1 - Decentralized VM Layer](#tier-1---decentralized-vm-layer)
             * [Keeper Smart Contracts](#keeper-smart-contracts)
@@ -19,8 +18,9 @@ Table of Contents
          * [On-Chain Access Control](#on-chain-access-control)
       * [Project Repositories](#project-repositories)
 
-
 ---
+
+**Note: The Provider was renamed as Aquarius and some of its functionality was moved into Brizo. Some diagrams still use the old name.**
 
 
 This page is a central point for documenting the Ocean Architecture.
@@ -33,10 +33,9 @@ In the image below you can see a diagram of the initial High-Level Ocean Network
 
 In the above diagram you can see the following components (from top to bottom):
 
-
 - **Frontend** (Tier 3) - Application implemented using HTML + Javascript + CSS, running in the client side (user's browser).
 - **Data Science Tools** (Tier 3) - Applications executed by data scientists, typically getting access to the Ocean data and executing algorithms on top of that data
-- **Provider** (Tier 2) - Backend application providing some advanced network services. Executed typically by Marketplaces. Initially:
+- **Aquarius** (Tier 2) - Backend application providing some advanced network services. Executed typically by Marketplaces. Initially:
   - On-Chain access control.
   - Metadata storage.
   - Gathering of service proofs.
@@ -65,13 +64,13 @@ It is not a final product, but can be used as reference to implement further Mar
 Marketplaces will be running on the client side and will communicate with the following external components:
 
  - **Smart Contracts**. Enables interaction with the Ocean Smart Contracts that provide the Market business logic. This integration is implemented using the [Ethereum Javascript API (web3.js)](https://github.com/ethereum/web3.js/).
- - **Provider**. Enables access to asset's made accessible to consumers, and facilitates the Metadata management of assets for the publishers. This communication happens using HTTP API's.
+ - **Aquarius**. Enables access to asset's made accessible to consumers, and facilitates the Metadata management of assets for the publishers. This communication happens using HTTP API's.
 
 The frontend application will subscribe to the EVM transaction log, enabling the receipt of asynchronous messages. This will facilitate the triggering of automatic actions when some event(s) is raised (i.e. the request of an asset is triggered automatically when the purchase has been confirmed).
 
 ![Frontend High-Level Architecture](architecture/img/frontend-hl-arch.png)
 
-The Squid library showed in the above diagram encapsulates the logic to deal with the Ocean components (Keeper & Provider). Squid libraries in different languages are part of the Tier 2.
+The Squid library showed in the above diagram encapsulates the logic to deal with the Ocean components (such as Keeper nodes and Aquarius nodes). Squid libraries in different languages are part of the Tier 2.
 
 #### Data science Tools
 
@@ -92,18 +91,15 @@ Squid API as specification, can be implemented in different languages, initially
 
 The complete specification of the [Squid API](development/squid.md) can be reviewed as part of this repository.
 
+#### Aquarius
 
-#### Provider
+Aquarius is an application running in the backend (Python) that enables some advanced network capabilities:
 
-The Provider is an application running in the backend (Python) that enables some advanced network capabilities:
-
-- Metadata Management - Abstracts access to different Metadata stores, allowing Providers to integrate different metadata repositories. The OceanDB plugin system can integrate different data stores (ElasticSearch, MongoDB, BigChainDB) implementing the Oceandb interfaces.
-- Gathering of Service Proofs - Enables different kind of service proofs from different providers. For example - allowing the retrieval of receipt's from cloud providers to validate service delivery.
-- On-Chain Access Control - The Provider is in charge of the on-chain validation that a consumer is entitled to get access to an asset or service. This happens by integrating with the Keeper from the Provider side.
+**Metadata Management** - Abstracts access to different Metadata stores, allowing Aquarius to integrate different metadata repositories. The OceanDB plugin system can integrate different data stores (Elasticsearch, MongoDB, BigchainDB) implementing the OceanDB interfaces.
 
 The high-level architecture can be seen in the following diagram:
 
-![Provider High-Level Architecture](architecture/img/provider-hl-arch.png)
+![Aquarius High-Level Architecture](architecture/img/provider-hl-arch.png)
 
 #### Brizo
 
@@ -111,11 +107,12 @@ Brizo is component providing additional capabilities to the **Publishers**. It a
 The most basic scenario of a Publisher, is to provide access to the Assets this Publisher owns or manage. In addition to this, other extended services could be offered as extension to this.
 Brizo enables, interacting with the infrastructure providers, to build additional services based in that infrastructure like:
 
-* Computing on top of the data without moving the data
-* Storage services for new derived assets
+- Computing on top of the data without moving the data
+- Storage services for new derived assets
+- Gathering of Service Proofs - Enables different kind of service proofs from different providers. For example - allowing the retrieval of receipts from cloud providers to validate service delivery.
+- On-Chain Access Control - Brizo is in charge of the on-chain validation that a consumer is entitled to get access to an asset or service. This happens by integrating with the Keeper from the Brizo side.
 
 ![Brizo High-Level Architecture](architecture/img/brizo-hl-arch.png)
-
 
 ### Tier 1 - Decentralized VM Layer
 

--- a/doc/architecture/secret-store.md
+++ b/doc/architecture/secret-store.md
@@ -18,6 +18,8 @@ Table of Contents
 
 This page describes the Parity Secret Store integration.
 
+**Note: When this document was written, there was a component named the Provider, and there was no Aquarius or Ocean. Since then, the Provider was renamed to Aquarius, and some of the functionality of the Provider was moved over to Brizo, including the functionality related to secrets and access control.**
+
 # Motivation
 
 The current implementation of Ocean Protocol, detailed in the [OEP-10](https://github.com/oceanprotocol/OEPs/tree/master/10) requires Publishers, Consumers, Providers and Smart Contracts
@@ -71,7 +73,7 @@ This logic was encapsulated as part of the [Ocean Protocol Secret Store Java Cli
 This method allows to a Publisher to given a resource unique id and a document, to retrieve the document encrypted and store/distribute the keys used to encrypt/decrypt the document in the Secret Store cluster.
 The concept of document to encrypt is totally flexible. A document could be one or multiple URL's, access tokens to an external resource, etc.
 Typically in Ocean, during the Asset access phase, what we are encrypting/decrypting is the URL to get access to an Asset that is stored in a cloud provider.
-This could be extended in following phases, allowing to encrypt/decrypt a unique Marketplace/Provider (_sic_, the Provider was later renamed to Aquarius) URL that a part of give access to a resource, as a previous phase setup the cloud provider access policies for a specific user/ip address.
+This could be extended in following phases, allowing to encrypt/decrypt a unique Marketplace/Provider URL that a part of give access to a resource, as a previous phase setup the cloud provider access policies for a specific user/ip address.
 
 The lower level implementation is represented in the following flow:
 
@@ -142,7 +144,7 @@ Having this into account, at network launch, the initial Ocean deployment could 
 
 * A pool of Parity Ethereum client/nodes used to deployed the Ocean Keeper Contracts and syncronize with the Ethereum network
 * A Secret Store cluster allowing to share secrets between parties
-* A possible Commons Marketplace with his own Provider (_sic_, the Provider was later renamed to Aquarius) agent and Ocean DB instance. It would be used to demonstrate the Ocean capabilities using free/open assets
+* A possible Commons Marketplace with his own Provider agent and Ocean DB instance. It would be used to demonstrate the Ocean capabilities using free/open assets
 
 ![Ocean initial deployment](img/ocean-initial-deployment.png)
 

--- a/doc/architecture/secret-store.md
+++ b/doc/architecture/secret-store.md
@@ -71,7 +71,7 @@ This logic was encapsulated as part of the [Ocean Protocol Secret Store Java Cli
 This method allows to a Publisher to given a resource unique id and a document, to retrieve the document encrypted and store/distribute the keys used to encrypt/decrypt the document in the Secret Store cluster.
 The concept of document to encrypt is totally flexible. A document could be one or multiple URL's, access tokens to an external resource, etc.
 Typically in Ocean, during the Asset access phase, what we are encrypting/decrypting is the URL to get access to an Asset that is stored in a cloud provider.
-This could be extended in following phases, allowing to encrypt/decrypt a unique Marketplace/Provider URL that a part of give access to a resource, as a previous phase setup the cloud provider access policies for a specific user/ip address.
+This could be extended in following phases, allowing to encrypt/decrypt a unique Marketplace/Provider (_sic_, the Provider was later renamed to Aquarius) URL that a part of give access to a resource, as a previous phase setup the cloud provider access policies for a specific user/ip address.
 
 The lower level implementation is represented in the following flow:
 
@@ -142,7 +142,7 @@ Having this into account, at network launch, the initial Ocean deployment could 
 
 * A pool of Parity Ethereum client/nodes used to deployed the Ocean Keeper Contracts and syncronize with the Ethereum network
 * A Secret Store cluster allowing to share secrets between parties
-* A possible Commons Marketplace with his own Provider agent and Ocean DB instance. It would be used to demonstrate the Ocean capabilities using free/open assets
+* A possible Commons Marketplace with his own Provider (_sic_, the Provider was later renamed to Aquarius) agent and Ocean DB instance. It would be used to demonstrate the Ocean capabilities using free/open assets
 
 ![Ocean initial deployment](img/ocean-initial-deployment.png)
 

--- a/doc/architecture/squid.md
+++ b/doc/architecture/squid.md
@@ -1,5 +1,7 @@
 # Squid API
 
+**Note: "Provider" was renamed to Aquarius and some of its functionality was moved over to Brizo. This page hasn't been updated to reflect that change yet.**
+
 The Squid API is a Level-2 API built on top of core Ocean components. It's a facilitator or enabler, but it's not the only way to interact with Ocean.
 
 The goal of this doc is to help a developer develop a version of the Squid API in any programming language. Currently, the Squid API is defined for Object-Oriented languages such as JavaScript, Java, and Python (which are the three initial implementation languages).


### PR DESCRIPTION
The main page that got edited was the `doc/architecture` page. I did my best to make it accurate, i.e. not just renaming Provider to Aquarius, but also moving some of the old Provider functionality over to Brizo.

I didn't edit `squid.md` (other than to put a warning at the top) because I don't know all the details of how the Squid API changed when the Provider got renamed to Aquarius, and some of the Provider's functionality got moved over to Brizo.

I added a similar note at the top of the page about the secret store, because a proper rewriting of that doc is needed, but for now it's probably enough just to explain the changes at a high level.

I also did some heavy editing of the `PROJECT_MAP.md` file because it was out of date and was repeating some information (e.g. the list of main repos: now it just points to the big list of repos in `doc/architecture/repos.md`).
