### PR TITLE
Docs integration

### DIFF
--- a/PROJECT_MAP.md
+++ b/PROJECT_MAP.md
@@ -18,8 +18,8 @@ The current milestone is [Trilobite - Tethys Beta (v0.9)](https://github.com/oce
 
 ## Main Ocean Development Repositories
 
-See [doc/architecture/repos.md](doc/architecture/repos.md)
+See [Docs: Software Components](https://docs.oceanprotocol.com/concepts/components/)
 
 ## Ocean Architecture
 
-See [doc/architecture.md](doc/architecture.md)
+See [Docs: Architecture](https://docs.oceanprotocol.com/concepts/architecture/)

--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
 [![banner](doc/img/repo-banner@2x.png)](https://oceanprotocol.com)
 
+<h1 align="center">dev-ocean: Ocean Engineering</h1>
+
 <p align="center">
-  <img src="https://media.giphy.com/media/Xbaqg3KwpxHjO/giphy.gif">
+  <img src="https://media.giphy.com/media/Xbaqg3KwpxHjO/giphy.gif" width="270">
 </p>
 
-<h1 align="center">Dev-Ocean: Ocean Engineering</h1>
-
-> 💧 Ocean Engineering Pages
+> 🕶 Ocean Engineering Pages with documentation about Development, DevOps, QA, Security, etc.
 > [oceanprotocol.com](https://oceanprotocol.com)
+
+**This repo contains internal documentation for all Ocean engineering processes. You will find most of the key documents on our [central documentation site](https://docs.oceanprotocol.com) under Core Concepts.**
 
 See [Ocean project map](https://github.com/oceanprotocol/engineering/blob/master/PROJECT_MAP.md) for current development status and handy links.
 
-
 The main objective of the Ocean Engineering practice is:
-
 
 * Simplify what we do in order to avoid reinventing the wheel.
 * Promote quality and security.
@@ -35,30 +35,24 @@ The engineering practice is based in a list of key [principles](doc/principles.m
 
 ## Areas
 
-The documentation is divided in different areas:
+This repo is divided into different areas:
 
+- [Docs: Architecture](https://docs.oceanprotocol.com/concepts/architecture/)
 - [Development](doc/development.md)
 - [DevOps](doc/devops.md)
 - [QA](doc/qa.md)
 - [Security](doc/security.md)
-- [Architecture](doc/architecture.md)
 - [Lifecycle](doc/alm.md)
-
 
 ## Additional Information
 
+- **[Ocean Protocol Documentation](https://docs.oceanprotocol.com)**
+- [Docs: Software Components](https://docs.oceanprotocol.com/concepts/components/)
 - [Ocean Github Boards](doc/alm/boards.md)
-- [GitHub Engineering Board](https://github.com/oceanprotocol/engineering/projects/1)
-- [GitHub Issues](https://github.com/oceanprotocol/engineering/issues)
-- [Milestones](https://github.com/oceanprotocol/engineering/milestones?direction=asc&sort=due_date&state=open)
-- [Github Project Repositories](doc/architecture/repos.md)
+- [GitHub Engineering Board](https://github.com/oceanprotocol/dev-ocean/projects/1)
+- [GitHub Issues](https://github.com/oceanprotocol/dev-ocean/issues)
+- [Milestones](https://github.com/oceanprotocol/dev-ocean/milestones?direction=asc&sort=due_date&state=open)
 
 ## Contributing
 
-We use GitHub as a means of maintaining and tracking issues and source code development.
-
-If you would like to contribute, please fork this repository, do work in a feature branch, and finally open a pull request for maintainers to review your changes.
-
-Ocean Protocol uses [C4 Standard process](https://github.com/unprotocols/rfc/blob/master/1/README.md) to manage changes in the source code.  Find here more details about [Ocean C4 OEP](https://github.com/oceanprotocol/OEPs/tree/master/1).
-
-
+- See [Docs: Contributing](https://docs.oceanprotocol.com/concepts/contributing/)

--- a/README.md
+++ b/README.md
@@ -53,6 +53,21 @@ This repo is divided into different areas:
 - [GitHub Issues](https://github.com/oceanprotocol/dev-ocean/issues)
 - [Milestones](https://github.com/oceanprotocol/dev-ocean/milestones?direction=asc&sort=due_date&state=open)
 
+## Integration into `oceanprotocol/docs`
+
+To include a markdown document from this repo on docs.oceanprotocol.com, you need to add 4 required values to a document's YAML frontmatter. E.g. for the [doc/architecture.md](doc/architecture.md) document:
+
+```yaml
+---
+title: Architecture Overview
+description: This page is a central point for documenting the architecture of Ocean Protocol.
+slug: /concepts/architecture/
+section: concepts
+---
+```
+
+For more requirements and information please see [External Content Files](https://github.com/oceanprotocol/docs#external-content-files) and [Markdown File Requirements](https://github.com/oceanprotocol/docs#markdown-file-requirements) on the [oceanprotocol/docs](https://github.com/oceanprotocol/docs#markdown-file-requirements) repo.
+
 ## Contributing
 
 - See [Docs: Contributing](https://docs.oceanprotocol.com/concepts/contributing/)

--- a/README.md
+++ b/README.md
@@ -9,29 +9,19 @@
 > 🕶 Ocean Engineering Pages with documentation about Development, DevOps, QA, Security, etc.
 > [oceanprotocol.com](https://oceanprotocol.com)
 
+---
+
 **This repo contains internal documentation for all Ocean engineering processes. You will find most of the key documents on our [central documentation site](https://docs.oceanprotocol.com) under Core Concepts.**
+
+---
+
+The Ocean Engineering practice follows a list of  [key principles](https://docs.oceanprotocol.com/concepts/principles/) based on the **CAMS** acronym (Culture, Automation, Measurement and Sharing).
+
+- [Docs: Engineering Principles](https://docs.oceanprotocol.com/concepts/principles/)
 
 See [Ocean project map](https://github.com/oceanprotocol/engineering/blob/master/PROJECT_MAP.md) for current development status and handy links.
 
-The main objective of the Ocean Engineering practice is:
-
-* Simplify what we do in order to avoid reinventing the wheel.
-* Promote quality and security.
-* Better communication about what we do and why we are doing it. Our community needs information!
-* Be more effective in order to make a better use of our time.
-* Use some common good principles & patterns. These can be useful!
-
-The engineering practice is based in a list of key [principles](doc/principles.md) based in the **CAMS** acronym (Culture, Automation, Measurement and Sharing).
-
-## Key Concepts
-
-- **Simplicity** - Everything we define should be thin and simple.
-- **Open Source** - We are building FLOSS, so Open Source and Open Standards.
-- **Openness** - Community first, open discussions, open documentation, open requirements.
-- **Quality** - New best practices should be oriented to promote a high quality product.
-- **Security** - Security MUST be a first class citizen.
-- **Automation** - We should automate as much as we can...it will make our lives easier.
-- **Team** - All of us are part of the team. All the best practices will be defined by all us.
+- [Project Map](https://github.com/oceanprotocol/engineering/blob/master/PROJECT_MAP.md)
 
 ## Areas
 
@@ -48,6 +38,7 @@ This repo is divided into different areas:
 
 - **[Ocean Protocol Documentation](https://docs.oceanprotocol.com)**
 - [Docs: Software Components](https://docs.oceanprotocol.com/concepts/components/)
+- [Docs: Engineering Principles](https://docs.oceanprotocol.com/concepts/principles/)
 - [Ocean Github Boards](doc/alm/boards.md)
 - [GitHub Engineering Board](https://github.com/oceanprotocol/dev-ocean/projects/1)
 - [GitHub Issues](https://github.com/oceanprotocol/dev-ocean/issues)

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -7,6 +7,8 @@ section: concepts
 
 **Note: The Provider was renamed as Aquarius and some of its functionality was moved into Brizo. Some diagrams still use the old name.**
 
+The Ocean Protocol architecture is implemented based on [OEP-03/ARCH](https://github.com/oceanprotocol/OEPs/tree/master/3).
+
 In the image below you can see a diagram of the initial High-Level Ocean Network Architecture:
 
 ![High-Level Architecture](architecture/img/high-level-architecture.png)

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -1,3 +1,9 @@
+---
+title: Architecture Overview
+description: This page is a central point for documenting the architecture of Ocean Protocol.
+slug: /concepts/architecture/
+section: concepts
+---
 
 Table of Contents
 

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -5,33 +5,7 @@ slug: /concepts/architecture/
 section: concepts
 ---
 
-Table of Contents
-
-   * [Table of Contents](#table-of-contents)
-   * [Architecture](#architecture)
-      * [Components](#components)
-         * [Tier 3 - Application Layer](#tier-3---application-layer)
-            * [Pleuston Frontend](#pleuston-frontend)
-            * [Data science Tools](#data-science-tools)
-         * [Tier 2 - Protocol Layer](#tier-2---protocol-layer)
-            * [Squid Libraries](#squid-libraries)
-            * [Aquarius](#aquarius)
-            * [Brizo](#brizo)
-         * [Tier 1 - Decentralized VM Layer](#tier-1---decentralized-vm-layer)
-            * [Keeper Smart Contracts](#keeper-smart-contracts)
-      * [Interactions](#interactions)
-         * [Assets registering and consumption](#assets-registering-and-consumption)
-         * [On-Chain Access Control](#on-chain-access-control)
-      * [Project Repositories](#project-repositories)
-
----
-
 **Note: The Provider was renamed as Aquarius and some of its functionality was moved into Brizo. Some diagrams still use the old name.**
-
-
-This page is a central point for documenting the Ocean Architecture.
-
-# Architecture
 
 In the image below you can see a diagram of the initial High-Level Ocean Network Architecture:
 
@@ -47,7 +21,6 @@ In the above diagram you can see the following components (from top to bottom):
   - Gathering of service proofs.
 - **Brizo** (Tier 2) - Backend application allowing to provide additional services to Publishers (Compute)
 - **Keeper Contracts** (Tier 1) - Solidity Smart Contracts running on the decentralized Ethereum Virtual Machine (EVM).
-
 
 ## Components
 
@@ -69,8 +42,8 @@ It is not a final product, but can be used as reference to implement further Mar
 
 Marketplaces will be running on the client side and will communicate with the following external components:
 
- - **Smart Contracts**. Enables interaction with the Ocean Smart Contracts that provide the Market business logic. This integration is implemented using the [Ethereum Javascript API (web3.js)](https://github.com/ethereum/web3.js/).
- - **Aquarius**. Enables access to asset's made accessible to consumers, and facilitates the Metadata management of assets for the publishers. This communication happens using HTTP API's.
+- **Smart Contracts**. Enables interaction with the Ocean Smart Contracts that provide the Market business logic. This integration is implemented using the [Ethereum Javascript API (web3.js)](https://github.com/ethereum/web3.js/).
+- **Aquarius**. Enables access to asset's made accessible to consumers, and facilitates the Metadata management of assets for the publishers. This communication happens using HTTP API's.
 
 The frontend application will subscribe to the EVM transaction log, enabling the receipt of asynchronous messages. This will facilitate the triggering of automatic actions when some event(s) is raised (i.e. the request of an asset is triggered automatically when the purchase has been confirmed).
 
@@ -82,7 +55,6 @@ The Squid library showed in the above diagram encapsulates the logic to deal wit
 
 Data science Tools are the interface to Ocean used by data scientists. Typically in Python (but not limited to it),
 those tools and libraries expose a high-level API allowing to integrate the Ocean capabilities in different kind of computation pipelines.
-
 
 ### Tier 2 - Protocol Layer
 
@@ -134,9 +106,6 @@ The Ocean Keeper implementation is where we put the following modules together:
 
 ![Contracts Architecture](architecture/img/contracts-structure.jpg)
 
-
-
-
 ## Interactions
 
 ### Assets registering and consumption
@@ -148,9 +117,3 @@ The lower level details about the consumption are included in the On-Chain Acces
 ### On-Chain Access Control
 
 ![On-Chain Access Control Flow](architecture/img/onchain-acl.png)
-
-## Project Repositories
-
-The Ocean Github project repositories can be found in the [repositories section](architecture/repos.md).
-
-

--- a/doc/architecture/computing-services.md
+++ b/doc/architecture/computing-services.md
@@ -77,18 +77,16 @@ The pre-conditions of this flow are:
 * The Publisher, specified in the Asset DDO the endpoint exposed by the Publisher (Brizo) to expose the computing services.
 * Service Agreement template is already predefined and whitelisted `on-chain`.
 
-#### Steps
-
-##### 1. Setup Service Agreement
+#### 1. Setup Service Agreement
 
 - The game begins with a data scientist is looking for a data asset but this data is attached to itsown compute service. He/She picks the asset, signs the agreement, then sends `signature, templateId` to the asset publisher.
 - The publisher setup a new service agreement instance `on-chain` using the data scientist (consumer's) signature.
 
-##### 2. Fulfill Lock Payment Condition
+#### 2. Fulfill Lock Payment Condition
 
 - As a data scientist, he/she listens to `ExecuteAgreement` on-chain event, in order to `lock the payment` in the `PaymentCondition.sol` contract and fulfill the condition.
 
-##### 3. Fulfill Upload Algorithm Condition
+#### 3. Fulfill Upload Algorithm Condition
 
 - The Data scientist, parses the DDO (using Squid) in order to see how the Publisher exposes a computing service. The computing service defines, `how to upload an algorithm to the publisher side`, and `how to consume an output`.
 - The data scientist, uploads the algorithm `off-chain` directly to the data set publisher `algorithm endpoint`.
@@ -96,25 +94,25 @@ The pre-conditions of this flow are:
 - The publisher receives the algorithm file/s, calculates the hash(algorithm file/s) and submits this hash in order to fulfill `uploadAlgorithm` condition. The keeper contracts automatically, verifies that both parties see the same files using (the `hash which is submitted by the publisher`, `signature submitted by data scientist` and `data scientist address`).
 - Please do note that the software component that is responsible for running the algorithm, attaching data assets and runs the container is the [Brizo](https://github.com/oceanprotocol/brizo). Moreover, it pulls the logs periodically and saves the outputs.
 
-##### 4. Fulfill Grant Access Condition
+#### 4. Fulfill Grant Access Condition
 
 - Meanwhile, the publisher starts computation machine/s, trains the model, collects logs and generates outputs (the derived asset). Finally, The publisher archives and uploads the outputs.
 - The publisher registers the derived asset (outputs) as a DID/DDO and assigns the ownership to the data scientist.
 - The publisher grants access to the data scientist using `secret-store` and fulfill the grant access condition.
 
-##### 5. Fulfill Release Payment
+#### 5. Fulfill Release Payment
 
 - Release Payment as a part of the reward function verifies all the above conditions. and the publisher can call it once the granted access is fulfilled within a `timeout`.
 - The data scientist can consume the derived asset (outputs) by calling the secret store which in turn check the permissions on-chain then downloads the outputs using the decryption keys.
 
-##### 6. Cancel Payment
+#### 6. Cancel Payment
 
 The payment can be cancelled only if:
 
 - The access to the derived asset (outputs) never delivered within timeout.
 - Payment never locked.
 
-##### 7. Agreement Fulfillement
+#### 7. Agreement Fulfillement
 
 The service agreement will be accepted as fulfilled agreement only if the `payment is released` to the service provider.
 

--- a/doc/architecture/computing-services.md
+++ b/doc/architecture/computing-services.md
@@ -1,55 +1,53 @@
-
-Table of Contents
-=================
-
-  * [Table of Contents](#table-of-contents)
-   * [Motivation](#motivation)
-   * [Architecture](#architecture)
-      * [Enabling Publisher Services (Brizo)](#enabling-publisher-services-brizo)
-      * [Responsibilities](#responsibilities)
-      * [Flow](#flow)
-      * [Next steps](#next-steps)
-
-
+---
+title: Computing Services
+description: This page describes the highlights of the integration of additional computing services.
+slug: /concepts/computing-services/
+section: concepts
 ---
 
-This page describes the highlights of the integration of additional computing services.
+## Motivation
 
-# Motivation
+The most basic scenario of a Publisher, is to provide access to the Assets this Publisher owns or manage.
 
-The most basic scenario of a Publisher, is to provide access to the Assets this Publisher owns or manage. 
-In addition to this, having this data ecosystem in place,
-Publishers could offer other related services in top of this. Some possibles scenarios are:
+In addition to this, having this data ecosystem in place, Publishers could offer other related services in top of this. Some possibles scenarios are:
 
-* The Publishers offer as a service the possibility of execute some computation on top of their data. This has some benefits:
-  - The data **never** leaves the Publisher enclave
-  - It's not necessary to move the data, the algorithm moves to the data
-  - Data Protection Regulation. Having only the data once and not moving it, 
-  makes easier to be compliant to the Data Protection Regulations applying to your data
+**1**
 
-* Storage services for new derived assets. As a result of the computation of the existing datasets, a new derived dataset could be created. Publishers could offer an additional service to make use of their existing storage capabilities.
-  This is always optional, being possible to the users using the compute services, to download the new derived datasets created as a result of this computation.
+The Publishers offer as a service the possibility of execute some computation on top of their data. This has some benefits:
 
-# Architecture
+- The data **never** leaves the Publisher enclave
+- It's not necessary to move the data, the algorithm moves to the data
+- Data Protection Regulation. Having only the data once and not moving it, makes easier to be compliant to the Data Protection Regulations applying to your data
 
-## Enabling Publisher Services (Brizo)
+**2**
+
+Storage services for new derived assets. As a result of the computation of the existing datasets, a new derived dataset could be created. Publishers could offer an additional service to make use of their existing storage capabilities.
+
+This is always optional, being possible to the users using the compute services, to download the new derived datasets created as a result of this computation.
+
+## Architecture
+
+### Enabling Publisher Services (Brizo)
 
 The direct interaction with the infrastructure where the data is, requires the execution of a component handled by Publishers.
+
 This component will be in charge of interact with the users, and manage the basics of own Publisher infrastructure to provide the additional services.
+
 This business logic supporting the some additional Publisher capabilities, is responsibility of a new technical component.
 
 The main & new key component introduced to support new Publisher services is named **Brizo**.
 
-_"Brizo is an ancient Greek goddess who was known as the protector of mariners, sailors, and fishermen. She was worshipped primarily by the women of Delos, who set out food offerings in small boats. Brizo was also known as a prophet specializing in the interpretation of dreams."_
+> Brizo is an ancient Greek goddess who was known as the protector of mariners, sailors, and fishermen. She was worshipped primarily by the women of Delos, who set out food offerings in small boats. Brizo was also known as a prophet specializing in the interpretation of dreams.
 
-In the "Ocean ecosystem", Brizo is the technical component executed by the **Publishers** allowing to them to provide extended data services.
-Brizo, as part of the Publisher ecosystem, includes the credentials to interact with the infrastructure (initially cloud, but could be on-premise).
+In the "Ocean ecosystem", Brizo is the technical component executed by the **Publishers** allowing to them to provide extended data services. Brizo, as part of the Publisher ecosystem, includes the credentials to interact with the infrastructure (initially cloud, but could be on-premise).
+
 Because of those credentials, the execution of Brizo **SHOULD NOT** be delegated to a third-party.
+
+<repo name="brizo"></repo>
 
 ![Brizo High-Level Architecture](img/brizo-hl-arch.png)
 
-
-## Responsibilities
+### Responsibilities
 
 The main responsibilities of the software are:
 
@@ -61,7 +59,7 @@ The main responsibilities of the software are:
 * Register new Assets derivated of the executions as new Ocean Assets
 * Provide **Proofs of Computation** to the Ocean Network
 
-## Flow
+### Flow
 
 ![Sequence Diagram for computing services](img/computing-service-flow.png)
 
@@ -79,52 +77,46 @@ The pre-conditions of this flow are:
 * The Publisher, specified in the Asset DDO the endpoint exposed by the Publisher (Brizo) to expose the computing services.
 * Service Agreement template is already predefined and whitelisted `on-chain`.
 
+#### Steps
 
-### Steps
+##### 1. Setup Service Agreement
 
-##### 1. Setup Service Agreement:
-
-- The game begins with a data scientist is looking for a data asset but this data is attached to itsown compute service. 
-He/She picks the asset, signs the agreement, then sends `signature, templateId` to the asset publisher. 
+- The game begins with a data scientist is looking for a data asset but this data is attached to itsown compute service. He/She picks the asset, signs the agreement, then sends `signature, templateId` to the asset publisher.
 - The publisher setup a new service agreement instance `on-chain` using the data scientist (consumer's) signature.
 
 ##### 2. Fulfill Lock Payment Condition
-- As a data scientist, he/she listens to `ExecuteAgreement` on-chain event, in order to `lock the payment` 
-in the `PaymentCondition.sol` contract and fulfill the condition.
+
+- As a data scientist, he/she listens to `ExecuteAgreement` on-chain event, in order to `lock the payment` in the `PaymentCondition.sol` contract and fulfill the condition.
+
 ##### 3. Fulfill Upload Algorithm Condition
-- The Data scientist, parses the DDO (using Squid) in order to see how the Publisher exposes a computing service.
-The computing service defines, `how to upload an algorithm to the publisher side`, and `how to consume an output`. 
+
+- The Data scientist, parses the DDO (using Squid) in order to see how the Publisher exposes a computing service. The computing service defines, `how to upload an algorithm to the publisher side`, and `how to consume an output`.
 - The data scientist, uploads the algorithm `off-chain` directly to the data set publisher `algorithm endpoint`.
-- Once, the algorithm file/s is/are uploaded, the data scientist calculates file/s hash, signs this hash and then submits 
-the signature **ONLY** on-chain. 
-- The publisher receives the algorithm file/s, calculates the hash(algorithm file/s) and submits this hash in order to fulfill `uploadAlgorithm` condition.
-The keeper contracts automatically, verifies that both parties see the same files using (the `hash which is submitted by the publisher`, `signature submitted by data scientist` and `data scientist address`).
-- Please do note that the software component that is responsible for running the algorithm, attaching data assets and runs the 
-container is the [Brizo](https://github.com/oceanprotocol/brizo). Moreover, it pulls the logs periodically and saves the outputs.
+- Once, the algorithm file/s is/are uploaded, the data scientist calculates file/s hash, signs this hash and then submits the signature **ONLY** on-chain. 
+- The publisher receives the algorithm file/s, calculates the hash(algorithm file/s) and submits this hash in order to fulfill `uploadAlgorithm` condition. The keeper contracts automatically, verifies that both parties see the same files using (the `hash which is submitted by the publisher`, `signature submitted by data scientist` and `data scientist address`).
+- Please do note that the software component that is responsible for running the algorithm, attaching data assets and runs the container is the [Brizo](https://github.com/oceanprotocol/brizo). Moreover, it pulls the logs periodically and saves the outputs.
 
 ##### 4. Fulfill Grant Access Condition
 
-- In the mean while, the publisher starts computation machine/s, trains the model, collects logs and generates outputs (the derived asset).
-Finally, The publisher archives and uploads the outputs.
+- Meanwhile, the publisher starts computation machine/s, trains the model, collects logs and generates outputs (the derived asset). Finally, The publisher archives and uploads the outputs.
 - The publisher registers the derived asset (outputs) as a DID/DDO and assigns the ownership to the data scientist.
 - The publisher grants access to the data scientist using `secret-store` and fulfill the grant access condition.
 
 ##### 5. Fulfill Release Payment
-- Release Payment as a part of the reward function verifies all the above conditions. and the publisher
-can call it once the granted access is fulfilled within a `timeout`. 
-- The data scientist can consume the derived asset (outputs) by calling the secret store which in turn check the permissions 
-on-chain then downloads the outputs using the decryption keys.
+
+- Release Payment as a part of the reward function verifies all the above conditions. and the publisher can call it once the granted access is fulfilled within a `timeout`.
+- The data scientist can consume the derived asset (outputs) by calling the secret store which in turn check the permissions on-chain then downloads the outputs using the decryption keys.
 
 ##### 6. Cancel Payment
 
 The payment can be cancelled only if:
+
 - The access to the derived asset (outputs) never delivered within timeout.
 - Payment never locked.
 
 ##### 7. Agreement Fulfillement
 
 The service agreement will be accepted as fulfilled agreement only if the `payment is released` to the service provider.
-
 
 ## Next steps
 
@@ -134,4 +126,3 @@ Next steps are:
 * Integrate different cloud providers/on-premise infrastructure
 * Support different kind of container flavours allowing to execute different kind of algorithms
 * Model extended service agreements supporting richer services
-

--- a/doc/architecture/repos.md
+++ b/doc/architecture/repos.md
@@ -1,45 +1,6 @@
 # GitHub Repositories
 
-This page is a central point for documenting the Ocean GitHub repositories in use.
+**Please have a look at our docs site for an overview of our repositories:**
 
-## Pleuston
-* [Ocean Frontend Pleuston](https://github.com/oceanprotocol/pleuston/)
-
-## Keeper
-* [Ocean Keeper Contracts](https://github.com/oceanprotocol/keeper-contracts/)
-
-## Aquarius
-* [Ocean Backend Aquarius](https://github.com/oceanprotocol/aquarius)
-
-## Libraries
-
-### Squid
-* [Ocean Squid JavaScript Library](https://github.com/oceanprotocol/squid-js)
-* [Ocean Squid Python Library](https://github.com/oceanprotocol/squid-py)
-* [Ocean Squid Java Library](https://github.com/oceanprotocol/squid-java)
-
-### Secret Store Client
-* [Ocean Secret Store JavaScript Cliern](https://github.com/oceanprotocol/secret-store-client-js)
-* [Ocean Secret Store Python Client](https://github.com/oceanprotocol/secret-store-client-py)
-* [Ocean Secret Store Java Client](https://github.com/oceanprotocol/secret-store-client-java)
-
-## OceanDB
-
-The following projects implement the OceanDB Metadata plugins system:
-
-* [OceanDB Driver Interface](https://github.com/oceanprotocol/oceandb-driver-interface)
-* [OceanDB BigchainDB Plugin](https://github.com/oceanprotocol/oceandb-bigchaindb-driver)
-* [OceanDB MongoDB Plugin](https://github.com/oceanprotocol/oceandb-mongodb-driver)
-* [OceanDB Elasticsearch Plugin](https://github.com/oceanprotocol/oceandb-elasticsearch-driver)
-
-## Contribution
-
-### OEP's
-* [Ocean OEP's](https://github.com/oceanprotocol/OEPs)
-
-### Bounties
-* [Ocean Openwaters](https://github.com/oceanprotocol/openwaters)
-
-### Project
-* [Ocean](https://github.com/oceanprotocol/ocean)
-* [Ocean Dev](https://github.com/oceanprotocol/dev-ocean)
+- **[Docs](https://docs.oceanprotocol.com/)**
+- **[Docs: Software Components](https://docs.oceanprotocol.com/concepts/components/)**

--- a/doc/architecture/secret-store.md
+++ b/doc/architecture/secret-store.md
@@ -1,36 +1,26 @@
-
-Table of Contents
-=================
-
-   * [Table of Contents](#table-of-contents)
-   * [Motivation](#motivation)
-   * [Introduction](#introduction)
-   * [Architecture](#architecture)
-      * [Encryption](#encryption)
-      * [Decryption](#decryption)
-      * [Authorization](#authorization)
-   * [Deployment](#deployment)
-      * [Links](#links)
-
-
 ---
-
-
-This page describes the Parity Secret Store integration.
+title: Secret Store
+description: This page describes the Parity Secret Store integration.
+slug: /concepts/secret-store/
+section: concepts
+---
 
 **Note: When this document was written, there was a component named the Provider, and there was no Aquarius or Ocean. Since then, the Provider was renamed to Aquarius, and some of the functionality of the Provider was moved over to Brizo, including the functionality related to secrets and access control.**
 
-# Motivation
+## Motivation
 
-The current implementation of Ocean Protocol, detailed in the [OEP-10](https://github.com/oceanprotocol/OEPs/tree/master/10) requires Publishers, Consumers, Providers and Smart Contracts
-to setup a complete negotiation between them. This integration was difficult, needs to scale to support delegation of permissions and because the complexity is a potential source of errors.
+The current implementation of Ocean Protocol, detailed in the [OEP-10](https://github.com/oceanprotocol/OEPs/tree/master/10) requires Publishers, Consumers, Providers and Smart Contracts to setup a complete negotiation between them.
+
+This integration was difficult, needs to scale to support delegation of permissions and because the complexity is a potential source of errors.
+
 Because of that we investigated alternative approaches to achieve a more secure and scalable way to share secrets between parties.
 
-
-# Introduction
+## Introduction
 
 Parity Secret Store is a feature included as part of the Parity Ethereum client that allows to store on the blockchain a fragmented ECDSA key which retrievals are controlled by a permissioned Smart Contract.
+
 The Secret Store implements a Threshold System that makes nodes unable to reconstruct the keys that allows to decrypt the documents.
+
 It means a Secret Store node, only saves a portion of the ECDSA key. The decryption key can only be generated if a consensus is reached by an amount of Secret Store nodes bigger than the threshold that the publisher of secret chooses.
 
 From the [Parity Secret Store documentation](https://wiki.parity.io/Secret-Store) page:
@@ -46,12 +36,10 @@ The Parity Secret Store is core technology that enables:
 * distributed key storage - private key shares are stored separately by every party and are never exposed neither to another parties, nor to external entities;
 * threshold retrieval according to blockchain permissions - all operations that are requiring private key, require at least t+1 parties to agree on ‘Permissioning contract’ state.
 
-
 This last point can enable to Ocean Protocol to have a solid mechanism to distribute encrypted contents between parties (Consumers and Publishers),
 and these contents only can be decrypted after a On-Chain authorization phase.
 
-
-# Architecture
+## Architecture
 
 The integration of the Secret could have the following characteristics:
 
@@ -63,16 +51,19 @@ The integration of the Secret could have the following characteristics:
 
 ![High-Level Architecture using Secret Store](img/secret-store-high-level.png)
 
-## Encryption
+### Encryption
 
 The standard Parity Secret Store publishing flow is the following:
 
 ![Secret Store Publishing Flow](img/ss-overview-2.jpg)
 
 This logic was encapsulated as part of the [Ocean Protocol Secret Store Java Client](https://github.com/oceanprotocol/secret-store-client-java), and is abstracted as part of the `encryptDocument` Squid method.
+
 This method allows to a Publisher to given a resource unique id and a document, to retrieve the document encrypted and store/distribute the keys used to encrypt/decrypt the document in the Secret Store cluster.
+
 The concept of document to encrypt is totally flexible. A document could be one or multiple URL's, access tokens to an external resource, etc.
 Typically in Ocean, during the Asset access phase, what we are encrypting/decrypting is the URL to get access to an Asset that is stored in a cloud provider.
+
 This could be extended in following phases, allowing to encrypt/decrypt a unique Marketplace/Provider URL that a part of give access to a resource, as a previous phase setup the cloud provider access policies for a specific user/ip address.
 
 The lower level implementation is represented in the following flow:
@@ -83,23 +74,26 @@ As a result of this flow, the encrypted document can be shared with the potentia
 
 The action of Granting permissions on-chain to a specific user is not part of this flow.
 
-## Decryption
+### Decryption
 
 The standard Parity Secret Store consuming flow is the following:
 
 ![Secret Store Publishing Flow](img/ss-overview-3.jpg)
 
 Again this logic is encapsulated as part of the `decryptDocument` Squid method. This method allows a to Consumer, given a resource unique id and a encrypted document (shared for the Publisher via Metadata or libp2p) to decrypt this document using the Secret Store cluster capabilities.
+
 Decryption only can be achieved if the Secret Store cluster achieve the quorum specified by the Publisher during the publishing process with the **threshold** attribute.
+
 The Secret Store validates on-chain the authorization permissions of the user trying to decrypt a document, not allowing to do it if those permissions are not satisfied.
 
 ![Ocean Secret Store Consuming Flow](img/secret-store-flow-consume.png)
 
-## Authorization
+### Authorization
 
 The Consumer on-chain authorization will be implemented using the Secret Store ACL capabilities.
 In the Secret Store configuration, an address of the authorization Smart Contract can be configured:
-```
+
+```solidity
 acl_contract = "6d6a34f2be1e76902a2fde049f317610cdf453eb"
 ```
 
@@ -120,13 +114,13 @@ Using this capability, a simple `checkPermissions` method could be as following:
 
 This could be easily adapted to use the Service Agreements approach.
 
-
-# Deployment
+## Deployment
 
 The Secret Store functionality is provided by a Permissioned cluster that will be executed as part of the Ocean Protocol basic infrastructure.
+
 The nodes part of this cluster only can be added changing the configuration of the members of the cluster, so a third-party malicious user can't join the cluster without changing the configuration of the other nodes.
 
-```
+```text
 [secretstore]
 
 // Here the list of all the nodes part of the Secret Store cluster
@@ -148,10 +142,12 @@ Having this into account, at network launch, the initial Ocean deployment could 
 
 ![Ocean initial deployment](img/ocean-initial-deployment.png)
 
-
 ## Links
 
 * [Parity Secret Store](https://wiki.parity.io/Secret-Store)
 * [ECDKG: A Distributed Key Generation Protocol Based on Elliptic Curve Discrete Logarithm](http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.124.4128&rank=1)
-* [Ocean Protocol Secret Store Java Client](https://github.com/oceanprotocol/secret-store-client-java)
 * [Secret Store Proof of Concept](https://github.com/oceanprotocol/poc-secret-store)
+
+<repo name="secret-store-client-js"></repo>
+<repo name="secret-store-client-py"></repo>
+<repo name="secret-store-client-java"></repo>

--- a/doc/architecture/squid.md
+++ b/doc/architecture/squid.md
@@ -1,8 +1,11 @@
-# Squid API
+---
+title: Squid API
+description: The Squid API is a Level-2 API built on top of core Ocean components. It's a facilitator or enabler, but it's not the only way to interact with Ocean.
+slug: /concepts/squid/
+section: concepts
+---
 
 **Note: "Provider" was renamed to Aquarius and some of its functionality was moved over to Brizo. This page hasn't been updated to reflect that change yet.**
-
-The Squid API is a Level-2 API built on top of core Ocean components. It's a facilitator or enabler, but it's not the only way to interact with Ocean.
 
 The goal of this doc is to help a developer develop a version of the Squid API in any programming language. Currently, the Squid API is defined for Object-Oriented languages such as JavaScript, Java, and Python (which are the three initial implementation languages).
 

--- a/doc/architecture/squid.md
+++ b/doc/architecture/squid.md
@@ -473,7 +473,7 @@ access = serviceAgreement.getAccess()
 
 Interface provides access to Order functions
 
-### getI
+### getId
 
 SYNC. Return the ID used by this order.
 
@@ -481,7 +481,7 @@ SYNC. Return the ID used by this order.
 id= order.getId()
 ```
 
-### getStatu
+### getStatus
 
 ASYNC. Using an order object, returns an integer representing the order status as defined in the keeper. It is described as an Enum.
 
@@ -495,7 +495,7 @@ Possible values are:
 status= order.getStatus()
 ```
 
-### commi
+### commit
 
 ASYNC. Publisher commits this order with the access token.
 
@@ -503,7 +503,7 @@ ASYNC. Publisher commits this order with the access token.
 isCommited= order.commit(accessToken)
 ```
 
-### pa
+### pay
 
 ASYNC. Pay for this order with given account.
 
@@ -511,7 +511,7 @@ ASYNC. Pay for this order with given account.
 paymentId= order.pay(consumerAccount)
 ```
 
-### verifyPaymen
+### verifyPayment
 
 SYNC. Given an order object, verifies if the order was paid.
 

--- a/doc/architecture/squid.md
+++ b/doc/architecture/squid.md
@@ -9,31 +9,6 @@ section: concepts
 
 The goal of this doc is to help a developer develop a version of the Squid API in any programming language. Currently, the Squid API is defined for Object-Oriented languages such as JavaScript, Java, and Python (which are the three initial implementation languages).
 
-<!--ts-->
-   * [Squid API](#squid-api)
-      * [Common](#common)
-         * [Getting an instance](#getting-an-instance)
-            * [Methods](#methods)
-      * [Ocean](#ocean)
-         * [Methods](#methods-1)
-      * [Account](#account)
-         * [Methods](#methods-2)
-      * [Asset](#asset)
-         * [Methods](#methods-3)
-      * [ServiceAgreement](#serviceagreement)
-         * [Methods](#methods-4)
-      * [Order](#order)
-         * [Methods](#methods-5)
-      * [SecretStore (Private)](#secretstore-private)
-         * [Methods](#methods-6)
-      * [DID-DDO-Library (Private)](#did-ddo-library-private)
-      * [Squid API Implementation state](#squid-api-implementation-state)
-      * [Examples](#examples)
-
-<!-- Added by: batman, at: 2018-10-18T09:08+02:00 -->
-
-<!--te-->
-
 ---
 
 **🐲🦑 THERE BE DRAGONS AND SQUIDS. This is in alpha state and you can expect running into problems. If you run into them, please open up [a new issue](https://github.com/oceanprotocol/dev-ocean/issues). 🦑🐲**

--- a/doc/architecture/squid.md
+++ b/doc/architecture/squid.md
@@ -9,6 +9,10 @@ section: concepts
 
 The goal of this doc is to help a developer develop a version of the Squid API in any programming language. Currently, the Squid API is defined for Object-Oriented languages such as JavaScript, Java, and Python (which are the three initial implementation languages).
 
+<repo name="squid-js"></repo>
+<repo name="squid-py"></repo>
+<repo name="squid-java"></repo>
+
 ---
 
 **🐲🦑 THERE BE DRAGONS AND SQUIDS. This is in alpha state and you can expect running into problems. If you run into them, please open up [a new issue](https://github.com/oceanprotocol/dev-ocean/issues). 🦑🐲**
@@ -86,8 +90,6 @@ class Balance {
 
 ### Getting an instance
 
-#### Methods
-
 ```
 getInstance(web3Dto, providerDto)
 ```
@@ -127,19 +129,28 @@ const ocean = await Ocean.getInstance({...})
 
 This class serves as the interface with Ocean Protocol. The Ocean class aggregates the list of **Account**s (ethereum accounts), list of **Asset**s, and a list of **Order** objects. The Ocean class aggregates the Keeper class, which in turn interfaces with the running Smart Contracts: Market, Token, and Auth. 
 
-### Methods
+### getAccounts
 
-* **getAccounts** - ASYNC. Returns all available accounts loaded via a wallet, or by Web3.
-```
+ASYNC. Returns all available accounts loaded via a wallet, or by Web3.
+
+```js
 array[Account] = ocean.getAccounts()
 ```
 
-* **searchAssets** - SYNC. Given a search query, returns a list of the Asset objects matching with that query. 
-```
+### searchAssets
+
+SYNC. Given a search query, returns a list of the Asset objects matching with that query.
+
+```js
 array[Asset] = ocean.searchAssets(searchQuery)
 ```
+
 You have to do a request to this endpoint:
+
+```text
 POST {provider.url}/api/v1/provider/assets/metadata/query
+```
+
 This method is expecting a json object that contains the following structure:
 
  ```  {
@@ -157,41 +168,59 @@ This method is expecting a json object that contains the following structure:
 
 The only mandatory argument is query or text, but you have to use only one of them. The other fields are optional.
 
-* **searchOrders** - (*TBD*) SYNC. Return a list of orders by search query. **Nice to Have**.
-```
+### searchOrders
+
+(*TBD*) SYNC. Return a list of orders by search query. **Nice to Have**.
+
+```js
 array[Order] = ocean.searchOrders(searchQuery)
 ```
 
-* **getOrdersByAccount** - ASYNC. Returns a list of orders by given account.
-```
+### getOrdersByAccount
+
+ASYNC. Returns a list of orders by given account.
+
+```js
 array[Order] = ocean.getOrdersByAccount(account)
 ```
 
-* **register** - ASYNC. High-level method publishing the metadata off-chain and registering the Service Agreement on-chain. It orchestrate the publishAssetMetadata and publishServiceAgreement, and creating a DDO methods.
-```
+### register
+
+ASYNC. High-level method publishing the metadata off-chain and registering the Service Agreement on-chain. It orchestrate the publishAssetMetadata and publishServiceAgreement, and creating a DDO methods.
+
+```js
 asset_did = ocean.register(asset)
 ```
 
-* **resolveDID** - SYNC. Given a DID, return the associated DID Document (DDO). The DDO is resolved by directly interacting with the keeper node. 
-```
+### resolveDID
+
+SYNC. Given a DID, return the associated DID Document (DDO). The DDO is resolved by directly interacting with the keeper node.
+
+```js
 DDO = ocean.resolveDID(did)
 ```
 
-- **getOrder** - ASYNC. Get an order from the given orderId.
+### getOrder
 
-```
+ASYNC. Get an order from the given orderId.
+
+```js
 Order = ocean.getOrder(orderId)
 ```
 
-* **getAsset** - ASYNC. Get an asset based on its identifier, in the form of a DID. 
+### getAsset
 
-```
+ASYNC. Get an asset based on its identifier, in the form of a DID. 
+
+```js
 Asset = ocean.getAsset(asset_DID)
 ```
 
-- **getServiceAgreement** - SYNC. Returns as serviceAgreement object based from the service agreement id (Publisher). **Nice to Have**.
+### getServiceAgreement
 
-```
+SYNC. Returns as serviceAgreement object based from the service agreement id (Publisher). **Nice to Have**.
+
+```js
 serviceAgreement = ocean.getServiceAgreement(serviceAgreementId)
 ```
 
@@ -199,128 +228,183 @@ serviceAgreement = ocean.getServiceAgreement(serviceAgreementId)
 
 Ocean Account object
 
-### Methods
+### getId
 
-* **getId** - SYNC. Return the Id used by this account.
-```
+ASYNC. Return the Id used by this account.
+
+```js
 id= account.getId()
 ```
 
-* **getOceanBalance** - ASYNC. Returns the Ocean Tokens balance for that account.
-```
+### getOceanBalance
+
+ASYNC. Returns the Ocean Tokens balance for that account.
+
+```js
 oceanBalance= account.getOceanBalance()
 ```
 
-* **getEtherBalance** - ASYNC. Returns the Ether balance for that account.
-```
+### getEtherBalance
+
+ASYNC. Returns the Ether balance for that account.
+
+```js
 ethBalance= account.getEtherBalance()
 ```
 
-* **getBalance** - ASYNC. Returns an instance of the Balance object for that account.
-```
+### getBalance
+
+ASYNC. Returns an instance of the Balance object for that account.
+
+```js
 balance= account.getBalance()
 ```
 
-* **requestTokens** - ASYNC. Request a number of Ocean Tokens. Returns the number of tokens accounted.
-```
+### requestTokens
+
+ASYNC. Request a number of Ocean Tokens. Returns the number of tokens accounted.
+
+```js
 amount= account.requestTokens(amountTokens)
 ```
 
 ## Asset
 
-Interface provides access to assets. 
+Interface provides access to assets.
 
-### Methods
+### getId
 
-* **getId** - SYNC. Return the Id used by this asset.
-```
+SYNC. Return the Id used by this asset.
+
+```js
 id= order.getId()
 ```
 
-* **purchase** - ASYNC. Given an Asset id/did or Asset object and Service Agreement, the Consumer created for the  class purchases an asset
-```
+### purchase
+
+ASYNC. Given an Asset id/did or Asset object and Service Agreement, the Consumer created for the  class purchases an asset
+
+```js
 order = asset.purchase(assetDID, serviceAgreementId, timeout)
 ```
 
-* **getDDO** - SYNC. Return the created DDO used by this asset.
-```
+### getDDO
+
+SYNC. Return the created DDO used by this asset.
+
+```js
 ddo = asset.getDDO()
 ```
 
-- **getDID** - SYNC. Return the DID used by this asset.
-```
+### getDID
+
+SYNC. Return the DID used by this asset.
+
+```js
 did = asset.getDID()
 ```
 
-* **publishMetadata** - SYNC. Given an asset metadata, register this metadata using the assets DDO off-chain. It returns a boolean with the result of the operation.
-```
+### publishMetadata
+
+SYNC. Given an asset metadata, register this metadata using the assets DDO off-chain. It returns a boolean with the result of the operation.
+
+```js
 status= asset.publishMetadata(metadata)
 ```
 
 You have to do a request to this endpoint:
+
+```text
 POST {provider.url}/api/v1/provider/assets/metadata
+```
+
 This method is expecting a json object that contains the following structure:
- ```   {"assetId": ,
-        "publisherId":,
-        "base":{
-            "name":,
-            "size":,
-            "author":,
-            "license":,
-            "contentType":,
-            "contentUrls":,
-            "price":,
-            "type":
-        }
-       }
- ```
+
+```json
+{
+    "assetId": ,
+    "publisherId":,
+    "base":{
+        "name":,
+        "size":,
+        "author":,
+        "license":,
+        "contentType":,
+        "contentUrls":,
+        "price":,
+        "type":
+    }
+}
+```
 
 In the base object there are more optional fields that you can check in the [provider API](https://github.com/oceanprotocol/provider/blob/develop/provider/app/assets.py).
 
-- **getMetadata** - SYNC. returns the metadata stored off chanin by using the asset DDO. Internally calls Ocean.resolveDID(did).
+### getMetadata
 
-```
+SYNC. returns the metadata stored off chanin by using the asset DDO. Internally calls Ocean.resolveDID(did).
+
+```js
 metadata= asset.getMetadata()
 ```
 
 You have to do a request to this endpoint:
-GET {provider.url}/api/v1/provider/assets/metadata/<asset_id>
 
-* **updateMetadata** - SYNC. Given an asset metadata, update the metadata using the asset DDO off-chain. This method replace the complete existing DDO by the DDO provided. It returns a boolean with the result of the operation.
+```text
+GET {provider.url}/api/v1/provider/assets/metadata/<asset_id>
 ```
+
+### updateMetadata
+
+SYNC. Given an asset metadata, update the metadata using the asset DDO off-chain. This method replace the complete existing DDO by the DDO provided. It returns a boolean with the result of the operation.
+
+```js
 status= asset.updateMetadata(metadata)
 ```
 
 You have to do a request to this endpoint:
+
+```text
 PUT {provider.url}/api/v1/provider/assets/metadata
+```
+
 This method is expecting a json object that contains the following structure:
- ```   {"assetId": ,
-        "publisherId":,
-        "base":{
-            "name":,
-            "size":,
-            "author":,
-            "license":,
-            "contentType":,
-            "contentUrls":,
-            "price":,
-            "type":
-        },
-        "curation":{
-            "rating":
-            "numVotes":
-        }
-       }
- ```
+
+```json
+{
+    "assetId": ,
+    "publisherId":,
+    "base":{
+        "name":,
+        "size":,
+        "author":,
+        "license":,
+        "contentType":,
+        "contentUrls":,
+        "price":,
+        "type":
+    },
+    "curation":{
+        "rating":
+        "numVotes":
+    }
+    }
+```
+
 In the base object there are more optional fields that you can check in the [provider API](https://github.com/oceanprotocol/provider/blob/develop/provider/app/assets.py).
 
-* **retireMetadata** - ASYNC. Given an Asset metadata, this method delete logically the Asset Metadata. **Nice to Have**
-```
+### retireMetadata
+
+ASYNC. Given an Asset metadata, this method delete logically the Asset Metadata. **Nice to Have**
+
+```js
 asset.retireMetadata(metadata)
 ```
 
-* **getServiceAgreements** - SYNC. Get a list of the service agreements published for this asset. providerId could be optional. **Nice to Have**
-```
+### getServiceAgreements
+
+SYNC. Get a list of the service agreements published for this asset. providerId could be optional. **Nice to Have**
+
+```js
 [serviceAgreementIds] = asset.getServiceAgreements(providerId)
 ```
 
@@ -328,39 +412,52 @@ asset.retireMetadata(metadata)
 
 Interface provides access to ServiceAgreement functions
 
-### Methods
+### getId
 
-* **getId** - SYNC. Return the Id used by this serviceAgreement.
-```
+SYNC. Return the Id used by this serviceAgreement.
+
+```js
 id = serviceAgreement.getId()
 ```
 
-- **getPrice** - SYNC. Given a service agreement id, get's the asset price information existing on-chain.
+### getPrice
 
-```
+SYNC. Given a service agreement id, get's the asset price information existing on-chain.
+
+```js
 price = serviceAgreement.getPrice(serviceAgreementId)
 tbd
 ```
 
-* **getStatus** - SYNC. Return's the status of a Service Agreement. Possible values are (0=> Pending, 1=> Enabled, 2=> Retired)
+### getStatus
 
-```
+SYNC. Return's the status of a Service Agreement. Possible values are (0=> Pending, 1=> Enabled, 2=> Retired)
+
+```js
 status = serviceAgreement.getStatus()
 ```
 
-* **publish** - ASYNC. The Publisher register a Service Agreement related with the Asset, returns a ServiceAgreement object
+### publish
 
-```
+ASYNC. The Publisher register a Service Agreement related with the Asset, returns a ServiceAgreement object
+
+```js
 serviceAgreement = serviceAgreement.publish(providerId, price, ..)
 ```
 
-* **retire** - ASYNC. Given a Service Agreement object, the Publisher retire a Service Agreement. It changes the status to the value 2=>Retired.
-```
+### retire
+
+ASYNC. Given a Service Agreement object, the Publisher retire a Service Agreement. It changes the status to the value 2=>Retired.
+
+```js
 result = serviceAgreement.retire()
 ```
 
-* **getAccess** - SYNC. Get all the information required to get access to an asset after the purchase process
-```
+### getAccess
+
+SYNC. Get all the information required to get access to an asset after the purchase process
+
+```js
 access = serviceAgreement.getAccess()
 ```
 
@@ -368,35 +465,51 @@ access = serviceAgreement.getAccess()
 
 Interface provides access to Order functions
 
-### Methods
+### getI
 
-* **getId** - SYNC. Return the Id used by this order.
-```
+SYNC. Return the Id used by this order.
+
+```js
 id= order.getId()
 ```
 
-* **getStatus** - ASYNC. Using an order object, returns an integer representing the order status as defined in the keeper. It is described as an Enum Possible values are (0=>Pending, 1=>Paid, 2=>Canceled)
-```
+### getStatu
+
+ASYNC. Using an order object, returns an integer representing the order status as defined in the keeper. It is described as an Enum Possible values are (0=>Pending, 1=>Paid, 2=>Canceled)
+
+```js
 status= order.getStatus()
 ```
 
-* **commit** - ASYNC. Publisher commits this order with the access token.
-```
+### commi
+
+ASYNC. Publisher commits this order with the access token.
+
+```js
 isCommited= order.commit(accessToken)
 ```
 
-* **pay** - ASYNC. Pay for this order with given account.
-```
+### pa
+
+ASYNC. Pay for this order with given account.
+
+```js
 paymentId= order.pay(consumerAccount)
 ```
 
-* **verifyPayment** - SYNC. Given an order object, verifies if the order was paid.
-```
+### verifyPaymen
+
+SYNC. Given an order object, verifies if the order was paid.
+
+```js
 status= order.verifyPayment()
 ```
 
-* **consume** - ASYNC. Get all the information required to get access to an asset after the purchase process, using the internal assetId and serviceAgreementId
-```
+### consum
+
+ASYNC. Get all the information required to get access to an asset after the purchase process, using the internal assetId and serviceAgreementId
+
+```js
 url= order.consume(consumerAccount)
 ```
 
@@ -406,15 +519,21 @@ Interface provides access to SecretStore functions
 
 ### Methods
 
-* **encryptDocument** - SYNC. **Private function** encapsulated as part of the **register** function. It integrates the Parity Ethereum & Secret Store API allowing to encrypt a document.
+### encryptDocumen
+
+SYNC. **Private function** encapsulated as part of the **register** function. It integrates the Parity Ethereum & Secret Store API allowing to encrypt a document.
 Given by a **Publisher** an unique resource id (did), the document to encrypt and the Secret Store cluster threshold (could be pre-defined to a fixed number), integrate the Secret Store API's to encrypt the document.
-```
+
+```js
 encryptedDocument= secretStore.encryptDocument(did, document, threshold)
 ```
 
-* **decryptDocument** - SYNC.  **Private function** encapsulated as part of the **getAssetAccess** function. It integrates the Parity Ethereum & Secret Store API allowing to decrypt a document if the user executing this function is authorized by a Smart Contract.
+### decryptDocumen
+
+SYNC.  **Private function** encapsulated as part of the **getAssetAccess** function. It integrates the Parity Ethereum & Secret Store API allowing to decrypt a document if the user executing this function is authorized by a Smart Contract.
 Given by a **Consumer** an unique resource id (did) and the document encrypted, this functions integrates the Secret Store API's to decrypt the document. The on-chain authorization phase is transparent for the user.
-```
+
+```js
 document= secretStore.decryptDocument(did, encryptedDocument)
 ```
 
@@ -475,4 +594,6 @@ Private API
 
 ## Examples
 
-For examples please see [Tuna](https://github.com/oceanprotocol/tuna)
+For examples please see [Tuna](https://github.com/oceanprotocol/tuna).
+
+<repo name="tuna"></repo>

--- a/doc/architecture/squid.md
+++ b/doc/architecture/squid.md
@@ -90,24 +90,25 @@ class Balance {
 
 ### Getting an instance
 
-```
+```java
 getInstance(web3Dto, providerDto)
 ```
 
-Parameters:
+#### Parameters
 
-* web3Dto - Web3 client wrapped in a DTO object to avoid coupling with specific web3 specific libraries
-* providerDto - Ocean Provider client wrapped in a DTO object
+* `web3Dto` - Web3 client wrapped in a DTO object to avoid coupling with specific web3 specific libraries
+* `providerDto` - Ocean Provider client wrapped in a DTO object
 
-This method returns an instance of the **Ocean** class. It allows to get access to the other Ocean core methods
+This method returns an instance of the **Ocean** class. It allows to get access to the other Ocean core methods.
 
-In Python
-Instantiate an ocean object
+### Instantiate an Ocean object
+
+In Python:
 
 ```python
 ocean = Ocean(web3Dto, providerDto)
 
-# for comaptability use get_instance to return an Ocean object
+# for compatibility use get_instance to return an Ocean object
 ocean = Ocean.get_instance(web3Dto, providerDto)
 
 class Ocean:
@@ -117,9 +118,9 @@ class Ocean:
     return Ocean(web3Dto, providerDto)
 ```
 
-In JavaScript
+In JavaScript:
 
-```javascript
+```js
 import { Ocean } from '@oceanprotocol/squid'
 
 const ocean = await Ocean.getInstance({...})
@@ -127,7 +128,7 @@ const ocean = await Ocean.getInstance({...})
 
 ## Ocean
 
-This class serves as the interface with Ocean Protocol. The Ocean class aggregates the list of **Account**s (ethereum accounts), list of **Asset**s, and a list of **Order** objects. The Ocean class aggregates the Keeper class, which in turn interfaces with the running Smart Contracts: Market, Token, and Auth. 
+This class serves as the interface with Ocean Protocol. The Ocean class aggregates the list of **Account**s (ethereum accounts), list of **Asset**s, and a list of **Order** objects. The Ocean class aggregates the Keeper class, which in turn interfaces with the running Smart Contracts: Market, Token, and Auth.
 
 ### getAccounts
 
@@ -153,16 +154,17 @@ POST {provider.url}/api/v1/provider/assets/metadata/query
 
 This method is expecting a json object that contains the following structure:
 
- ```  {
-        "offset": 100,
-        "page": 0,
-        "query": {
-          "value": 1
-        },
-        "sort": {
-          "value": 1
-        },
-        "text": "Office"
+ ```json
+{
+    "offset": 100,
+    "page": 0,
+    "query": {
+        "value": 1
+    },
+    "sort": {
+        "value": 1
+    },
+    "text": "Office"
 }
  ```
 
@@ -170,7 +172,7 @@ The only mandatory argument is query or text, but you have to use only one of th
 
 ### searchOrders
 
-(*TBD*) SYNC. Return a list of orders by search query. **Nice to Have**.
+(*TBD*) SYNC. Return a list of orders by search query. _Nice to Have_.
 
 ```js
 array[Order] = ocean.searchOrders(searchQuery)
@@ -218,7 +220,7 @@ Asset = ocean.getAsset(asset_DID)
 
 ### getServiceAgreement
 
-SYNC. Returns as serviceAgreement object based from the service agreement id (Publisher). **Nice to Have**.
+SYNC. Returns as serviceAgreement object based from the service agreement id (Publisher). _Nice to Have_.
 
 ```js
 serviceAgreement = ocean.getServiceAgreement(serviceAgreementId)
@@ -226,7 +228,7 @@ serviceAgreement = ocean.getServiceAgreement(serviceAgreementId)
 
 ## Account
 
-Ocean Account object
+Ocean Account object.
 
 ### getId
 
@@ -274,7 +276,7 @@ Interface provides access to assets.
 
 ### getId
 
-SYNC. Return the Id used by this asset.
+SYNC. Return the ID used by this asset.
 
 ```js
 id= order.getId()
@@ -282,7 +284,7 @@ id= order.getId()
 
 ### purchase
 
-ASYNC. Given an Asset id/did or Asset object and Service Agreement, the Consumer created for the  class purchases an asset
+ASYNC. Given an Asset ID/DID or Asset object and Service Agreement, the Consumer created for the  class purchases an asset
 
 ```js
 order = asset.purchase(assetDID, serviceAgreementId, timeout)
@@ -322,7 +324,7 @@ This method is expecting a json object that contains the following structure:
 
 ```json
 {
-    "assetId": ,
+    "assetId":,
     "publisherId":,
     "base":{
         "name":,
@@ -337,7 +339,7 @@ This method is expecting a json object that contains the following structure:
 }
 ```
 
-In the base object there are more optional fields that you can check in the [provider API](https://github.com/oceanprotocol/provider/blob/develop/provider/app/assets.py).
+In the base object there are more optional fields that you can check in the [provider API](https://github.com/oceanprotocol/aquarius/blob/develop/aquarius/app/assets.py).
 
 ### getMetadata
 
@@ -384,13 +386,13 @@ This method is expecting a json object that contains the following structure:
         "type":
     },
     "curation":{
-        "rating":
+        "rating": ,
         "numVotes":
     }
-    }
+}
 ```
 
-In the base object there are more optional fields that you can check in the [provider API](https://github.com/oceanprotocol/provider/blob/develop/provider/app/assets.py).
+In the base object there are more optional fields that you can check in the [provider API](https://github.com/oceanprotocol/aquarius/blob/develop/aquarius/app/assets.py).
 
 ### retireMetadata
 
@@ -402,7 +404,7 @@ asset.retireMetadata(metadata)
 
 ### getServiceAgreements
 
-SYNC. Get a list of the service agreements published for this asset. providerId could be optional. **Nice to Have**
+SYNC. Get a list of the service agreements published for this asset. providerId could be optional. _Nice to Have_
 
 ```js
 [serviceAgreementIds] = asset.getServiceAgreements(providerId)
@@ -410,11 +412,11 @@ SYNC. Get a list of the service agreements published for this asset. providerId 
 
 ## ServiceAgreement
 
-Interface provides access to ServiceAgreement functions
+Interface provides access to ServiceAgreement functions.
 
 ### getId
 
-SYNC. Return the Id used by this serviceAgreement.
+SYNC. Return the ID used by this serviceAgreement.
 
 ```js
 id = serviceAgreement.getId()
@@ -422,7 +424,7 @@ id = serviceAgreement.getId()
 
 ### getPrice
 
-SYNC. Given a service agreement id, get's the asset price information existing on-chain.
+SYNC. Given a service agreement ID, gets the asset price information existing on-chain.
 
 ```js
 price = serviceAgreement.getPrice(serviceAgreementId)
@@ -431,7 +433,13 @@ tbd
 
 ### getStatus
 
-SYNC. Return's the status of a Service Agreement. Possible values are (0=> Pending, 1=> Enabled, 2=> Retired)
+SYNC. Returns the status of a Service Agreement.
+
+Possible values are:
+
+- `0` => Pending
+- `1` => Enabled
+- `2` => Retired
 
 ```js
 status = serviceAgreement.getStatus()
@@ -447,7 +455,7 @@ serviceAgreement = serviceAgreement.publish(providerId, price, ..)
 
 ### retire
 
-ASYNC. Given a Service Agreement object, the Publisher retire a Service Agreement. It changes the status to the value 2=>Retired.
+ASYNC. Given a Service Agreement object, the Publisher retire a Service Agreement. It changes the status to the value `2` => Retired.
 
 ```js
 result = serviceAgreement.retire()
@@ -467,7 +475,7 @@ Interface provides access to Order functions
 
 ### getI
 
-SYNC. Return the Id used by this order.
+SYNC. Return the ID used by this order.
 
 ```js
 id= order.getId()
@@ -475,7 +483,13 @@ id= order.getId()
 
 ### getStatu
 
-ASYNC. Using an order object, returns an integer representing the order status as defined in the keeper. It is described as an Enum Possible values are (0=>Pending, 1=>Paid, 2=>Canceled)
+ASYNC. Using an order object, returns an integer representing the order status as defined in the keeper. It is described as an Enum.
+
+Possible values are:
+
+- `0` => Pending
+- `1` => Paid
+- `2` =>Canceled
 
 ```js
 status= order.getStatus()
@@ -505,9 +519,9 @@ SYNC. Given an order object, verifies if the order was paid.
 status= order.verifyPayment()
 ```
 
-### consum
+### consume
 
-ASYNC. Get all the information required to get access to an asset after the purchase process, using the internal assetId and serviceAgreementId
+ASYNC. Get all the information required to get access to an asset after the purchase process, using the internal `assetId` and `serviceAgreementId`.
 
 ```js
 url= order.consume(consumerAccount)
@@ -517,21 +531,24 @@ url= order.consume(consumerAccount)
 
 Interface provides access to SecretStore functions
 
-### Methods
+### encryptDocument
 
-### encryptDocumen
+SYNC. **Private function** encapsulated as part of the `register` function.
 
-SYNC. **Private function** encapsulated as part of the **register** function. It integrates the Parity Ethereum & Secret Store API allowing to encrypt a document.
-Given by a **Publisher** an unique resource id (did), the document to encrypt and the Secret Store cluster threshold (could be pre-defined to a fixed number), integrate the Secret Store API's to encrypt the document.
+It integrates the Parity Ethereum & Secret Store API allowing to encrypt a document.
+
+Given by a **Publisher** an unique resource id (DID), the document to encrypt and the Secret Store cluster threshold (could be pre-defined to a fixed number), integrate the Secret Store APIs to encrypt the document.
 
 ```js
 encryptedDocument= secretStore.encryptDocument(did, document, threshold)
 ```
 
-### decryptDocumen
+### decryptDocument
 
-SYNC.  **Private function** encapsulated as part of the **getAssetAccess** function. It integrates the Parity Ethereum & Secret Store API allowing to decrypt a document if the user executing this function is authorized by a Smart Contract.
-Given by a **Consumer** an unique resource id (did) and the document encrypted, this functions integrates the Secret Store API's to decrypt the document. The on-chain authorization phase is transparent for the user.
+SYNC.  **Private function** encapsulated as part of the `getAssetAccess` function. 
+
+It integrates the Parity Ethereum & Secret Store API allowing to decrypt a document if the user executing this function is authorized by a Smart Contract.
+Given by a **Consumer** an unique resource id (DID) and the document encrypted, this functions integrates the Secret Store API's to decrypt the document. The on-chain authorization phase is transparent for the user.
 
 ```js
 document= secretStore.decryptDocument(did, encryptedDocument)

--- a/doc/principles.md
+++ b/doc/principles.md
@@ -1,11 +1,11 @@
 ---
 title: Ocean Engineering Principles
-description: Our engineering principles are based in the DevOps **CAMS** acronym (Culture, Automation, Measurement and Sharing).
+description: Our engineering principles are based on the DevOps **CAMS** acronym (Culture, Automation, Measurement and Sharing).
 slug: /concepts/principles/
 section: concepts
 ---
 
-The main objective of the Ocean Engineering practice is:
+The main objectives of the Ocean Engineering practice are:
 
 - Simplify what we do in order to avoid reinventing the wheel.
 - Promote quality and security.

--- a/doc/principles.md
+++ b/doc/principles.md
@@ -1,72 +1,76 @@
-
-Table of Contents
-=================
-
-   * [Ocean Engineering Principles](#ocean-engineering-principles)
-      * [Culture](#culture)
-      * [Automation](#automation)
-      * [Measurement](#measurement)
-      * [Sharing](#sharing)
-
+---
+title: Ocean Engineering Principles
+description: Our engineering principles are based in the DevOps **CAMS** acronym (Culture, Automation, Measurement and Sharing).
+slug: /concepts/principles/
+section: concepts
 ---
 
+The main objective of the Ocean Engineering practice is:
 
-# Ocean Engineering Principles
+- Simplify what we do in order to avoid reinventing the wheel.
+- Promote quality and security.
+- Better communication about what we do and why we are doing it. Our community needs information!
+- Be more effective in order to make a better use of our time.
+- Use some common good principles & patterns. These can be useful!
 
-Our engineering principles are based in the DevOps **CAMS** acronym (Culture, Automation, Measurement and Sharing).
+## Key Concepts
+
+- **Simplicity** - Everything we define should be thin and simple.
+- **Open Source** - We are building FLOSS, so Open Source and Open Standards.
+- **Openness** - Community first, open discussions, open documentation, open requirements.
+- **Quality** - New best practices should be oriented to promote a high quality product.
+- **Security** - Security MUST be a first class citizen.
+- **Automation** - We should automate as much as we can...it will make our lives easier.
+- **Team** - All of us are part of the team. All the best practices will be defined by all us.
 
 ## Culture
 
 The backbone of any organization is its culture. It can be considered the “way of life” of an organization.
+
 The Engineering practice is about more than acquiring new tools and taking on new technical methodologies. It’s about setting expectations and priorities, and establishing the fundamental beliefs that guide them.
+
 Key elements of this are:
 
-| Belief                    | Description |
-|:--------------------------|:------------|
-| Learn to Trust            | It is necessary to have the unified agreement and understanding that we are all on the same team.
-| Understand Motivations    | Conflicts often occur when people don’t understand each other and their motivation. Having common objectives and an understanding about the motivations of others helps achieve common goals.
-| Eliminate Blame           | Blame is pointless. In problematic situations it’s necessary to understand what went wrong and how to make sure it doesn’t happen again.
-| Anticipate Failure    | Constantly learn from mistakes and previous failures. Previous problems should be used to learn and provide the mechanisms to anticipate the failure again in the future.
-| Focus on Bottlenecks & Flow | Rethink the process and refactor constantly. Simple is better.
-| Eliminate Unplanned Work  | Unplanned work is common but it is important to understand that priorities should be taken into consideration. It means some lower priority issues may need to go on hold.
-| Be Continuous             | Iterate in release cycles at a constant pace. This provides a continuous flow of deliverables that add value.
-| Form Dedicated, Cross-Functional Teams | Arranging people around projects, rather than grouping them based off their skill sets.
-| Transparency              | Transparency improves efficiency and productivity, reduces time and boosts employees' engagement
-| Build Autonomy, Mastery and Purpose | It’s necessary to create a working environment where people feel they have autonomy, mastery and purpose. Rewarding people and reviewing goals ensures that the there is a clear single goal that everyone can focus on.
-
+| Belief                                 | Description |
+| :------------------------------------- | :---------- |
+| Learn to Trust                         | It is necessary to have the unified agreement and understanding that we are all on the same team. |
+| Understand Motivations                 | Conflicts often occur when people don’t understand each other and their motivation. Having common objectives and an understanding about the motivations of others helps achieve common goals. |
+| Eliminate Blame                        | Blame is pointless. In problematic situations it’s necessary to understand what went wrong and how to make sure it doesn’t happen again. |
+| Anticipate Failure                     | Constantly learn from mistakes and previous failures. Previous problems should be used to learn and provide the mechanisms to anticipate the failure again in the future. |
+| Focus on Bottlenecks & Flow            | Rethink the process and refactor constantly. Simple is better. |
+| Eliminate Unplanned Work               | Unplanned work is common but it is important to understand that priorities should be taken into consideration. It means some lower priority issues may need to go on hold. |
+| Be Continuous                          | Iterate in release cycles at a constant pace. This provides a continuous flow of deliverables that add value. |
+| Form Dedicated, Cross-Functional Teams | Arranging people around projects, rather than grouping them based off their skill sets. |
+| Transparency                           | Transparency improves efficiency and productivity, reduces time and boosts employees' engagement |
+| Build Autonomy, Mastery and Purpose    | It’s necessary to create a working environment where people feel they have autonomy, mastery and purpose. Rewarding people and reviewing goals ensures that the there is a clear single goal that everyone can focus on. |
 
 ## Automation
 
 Automation embraces every aspect of the software and systems lifecycle, including requirements gathering, design, development, testing, application deployment and operations support.
 
-| Benefit                   | Description |
-|:--------------------------|:------------|
-| Faster Time to Market     | Quick application deployments and easy communication to the different stakeholders make getting to market faster.
-| Continuous Integration    | People can easily do unit testing, code quality analysis, and then commit to the SCM to build from an IDE, all in an integrated tool setup without switching between systems.
-| Continuous Delivery       | Teams can automatically generate releases ready to be installed in any environment.
-
+| Benefit                | Description |
+| :--------------------- | :---------- |
+| Faster Time to Market  | Quick application deployments and easy communication to the different stakeholders make getting to market faster. |
+| Continuous Integration | People can easily do unit testing, code quality analysis, and then commit to the SCM to build from an IDE, all in an integrated tool setup without switching between systems. |
+| Continuous Delivery    | Teams can automatically generate releases ready to be installed in any environment. |
 
 ## Measurement
 
 If you can’t measure it, you can’t improve it. A successful Engineering & DevOps implementation will measure everything it can as often as it can.
 
-| Benefit                   | Description |
-|:--------------------------|:------------|
-| Performance               | Depending on the application, it involves gathering the key performance indicators. These are useful to understand the status and define proactive actions to improve the application's stability and performance.
-| Process                   | Reviewing the process performance to understand if the processes should be refactored.
-| People                    | Reviewing team member metrics to understand personal performance. Some could require support and they are not communicating it. Understanding the situation can make easier to help others.
-
+| Benefit     | Description |
+| :---------- | :---------- |
+| Performance | Depending on the application, it involves gathering the key performance indicators. These are useful to understand the status and define proactive actions to improve the application's stability and performance. |
+| Process     | Reviewing the process performance to understand if the processes should be refactored. |
+| People      | Reviewing team member metrics to understand personal performance. Some could require support and they are not communicating it. Understanding the situation can make easier to help others. |
 
 ## Sharing
 
 Today’s organizations and software require teams of people with different skills and specialized knowledge.
 To work efficiently, it’s important to work well together, and sharing is how you get there. **Sharing is Caring...**
 
-
-| Belief                    | Description |
-|:--------------------------|:------------|
-| Open Communication        | Open, honest and clear communication helps with sharing information. This applies to both Internal and External communication, from top to bottom and bottom to top.
-| Shared Knowledge          | Successful teams share their experiences. Knowledge should be shared and spread across all collaborators.
-| Accessible Information    | Expose metrics to everyone within your tribe that might be interested. Keep things simple and clear — explain how these metrics affect software delivery and overall company performance. Sharing progress data will also help foster a more effective culture.
-
-
+| Belief                 | Description |
+| :--------------------- | :---------- |
+| Open Communication     | Open, honest and clear communication helps with sharing information. This applies to both Internal and External communication, from top to bottom and bottom to top. |
+| Shared Knowledge       | Successful teams share their experiences. Knowledge should be shared and spread across all collaborators. |
+| Accessible Information | Expose metrics to everyone within your tribe that might be interested. Keep things simple and clear — explain how these metrics affect software delivery and overall company performance. Sharing progress data will also help foster a more effective culture. |


### PR DESCRIPTION
Formatting some docs for inclusion in new docs site. Selecting docs from this repo for inclusion on docs site is a manual process to ensure a basic editorial workflow. For now, we start with all contents of the `/architecture` docs. And the `principles.md` doc.

In tandem with https://github.com/oceanprotocol/docs/pull/15

### The rules of the docs

On new docs site, markdown documents are included and pages are generated for them automatically when they have 4 required values in their frontmatter:

```yaml
---
title: Architecture Overview
description: This page is a central point for documenting the architecture of Ocean Protocol.
slug: /concepts/architecture/
section: concepts
---
```

- on build time, the docs site queries all markdown documents in this repo
- if the above 4 values are found as part of a document's frontmatter, a page will be generated automatically, accessible under the defined `slug`
- this will NOT include this page in the doc's sidebar navigation, this needs to be done manually in the docs repo in one of the sidebar files. This is so you can check out everything before exposing it to visitors, and to ensure editorial workflow of the categorization
- docs from this repo are all put under `section: concepts`
- no TOC please, will be generated automatically on docs site, e.g.:
  <img width="745" alt="screen shot 2018-11-15 at 15 12 37" src="https://user-images.githubusercontent.com/90316/48558183-ebbeb200-e8e8-11e8-84ae-b9ac2719c057.png">
- start headings with `h2`, so `## My heading`
- you can reference repos with `<repo name="pleuston"></repo>`, on the generated docs page this will result in:
  <img width="708" alt="screen shot 2018-11-15 at 15 10 00" src="https://user-images.githubusercontent.com/90316/48558036-8965b180-e8e8-11e8-8eb1-a54bf424df02.png">
- when linking to other docs in this repo, either do:
  - for docs which are included in docs site already, link to their url there with the pattern 
    `[Docs: Document Title](https://docs.oceanprotocol.com/concepts/slug)`
  - for docs which are not included in docs site you can keep linking relatively to them
- for images and media, you can keep them in this repo as it is right now. Images will be automatically grabbed by the docs site on querying. When doing that, docs site will generate all sorts of image sizes to handle proper responsive images, so no need to keep an eye on image dimensions or file sizes
- for now, there's no automatic rebuilding of the docs site when content is changed in this repo. We will setup some automation around this, probably with web hooks, to accomplish that.

_...Developing..._