### PR TITLE
Copy-edited computing-services.md

### DIFF
--- a/doc/architecture/computing-services.md
+++ b/doc/architecture/computing-services.md
@@ -15,7 +15,7 @@ Some possibilities are:
 
    - The data **never** leaves the Publisher enclave.
    - It's not necessary to move the data; the algorithm is sent to the data.
-   - Having only one copy of the data and not moving it makes easier to be compliant with data protection regulations.
+   - Having only one copy of the data and not moving it makes it easier to be compliant with data protection regulations.
 
 2. A service to store newly-derived datasets. As a result of the computation on existing datasets, a new dataset could be created. Publishers could offer a storage service to make use of their existing storage capabilities. This is optional; users could also download the newly-derived datasets.
 
@@ -23,19 +23,19 @@ Some possibilities are:
 
 ### Enabling Publisher Services (Brizo)
 
-The direct interaction with the infrastructure where the data is requires the execution of a component handled by Publishers.
+The direct interaction with the infrastructure where the data resides requires the execution of a component handled by Publishers.
 
-This component will be in charge of interacting with users and managing the basics of a Publisher's infrastructure to provide the additional services.
+This component will be in charge of interacting with users and managing the basics of a Publisher's infrastructure to provide these additional services.
 
-This business logic supporting the additional Publisher capabilities is the responsibility of this new technical component.
+The business logic supporting these additional Publisher capabilities is the responsibility of this new technical component.
 
 The main and new key component introduced to support these additional Publisher services is named **Brizo**.
 
 > Brizo is an ancient Greek goddess who was known as the protector of mariners, sailors, and fishermen. She was worshipped primarily by the women of Delos, who set out food offerings in small boats. Brizo was also known as a prophet specializing in the interpretation of dreams.
 
-In the Ocean ecosystem, Brizo is the technical component executed by the **Publishers**, allowing to them to provide extended data services. Brizo, as part of the Publisher ecosystem, includes the credentials to interact with the infrastructure (initially in cloud providers, but it could be on-premise).
+In the Ocean ecosystem, Brizo is the technical component executed by the **Publishers**, which provides extended data services. Brizo, as part of the Publisher ecosystem, includes the credentials to interact with the infrastructure (initially in cloud providers, but it could be on-premise).
 
-Because of those credentials, the execution of Brizo **SHOULD NOT** be delegated to a third-party.
+Because of these credentials, the execution of Brizo **SHOULD NOT** be delegated to a third-party.
 
 <repo name="brizo"></repo>
 
@@ -45,12 +45,12 @@ Because of those credentials, the execution of Brizo **SHOULD NOT** be delegated
 
 The main responsibilities of Brizo are:
 
-* Expose an HTTP API allowing one to execute some extended data-related services (compute and/or storage).
-* Authorize the user on-chain using the proper Service Agreement. That is, validate that user requesting the service is allowed to use that service.
+* Expose an HTTP API allowing for the execution of some extended, data-related services (compute and/or storage).
+* Authorize the user on-chain using the proper Service Agreement. That is, validate that the user requesting the service is allowed to use that service.
 * Interact with the infrastructure (cloud/on-premise) using the Publisher's credentials.
 * Start/stop/execute computing instances with the algorithms provided by users.
 * Retrieve the logs generated during executions.
-* Register newly-derived assets arising from the executions (as new Ocean assets).
+* Register newly-derived assets arising from the executions (i.e. as new Ocean assets).
 * Provide **Proofs of Computation** to the Ocean Network.
 
 ### Flow
@@ -59,7 +59,7 @@ The main responsibilities of Brizo are:
 
 In the above diagram you can see the initial integration supported. It involves the following components/actors:
 
-* Data scientists - The final users who need to use some computing/storage services offered by the same Publisher as the data Publisher.
+* Data Scientists - The end users who need to use some computing/storage services offered by the same Publisher as the data Publisher.
 * Ocean Keeper - In charge of enforcing the Service Agreement by tracing conditions.
 * Publisher Infrastructure - The storage and computing systems where the Publisher's data resides (in a cloud provider or on-premise).
 * Publisher Agent (Brizo) - Orchestrates/provides additional Publisher services.
@@ -69,9 +69,9 @@ Before the flow can begin, the following pre-conditions must be met:
 
 * The Algorithm must be implemented in one of the languages/frameworks supported by the Publisher.
 * The Asset DDO must specify the Brizo endpoint exposed by the Publisher.
-* The Service Agreement template is already predefined and whitelisted `on-chain`.
+* The Service Agreement template must already be predefined and whitelisted `on-chain`.
 
-Now we describe the steps in the flow.
+The following describes the steps in the flow.
 
 #### 1. Set Up the Service Agreement
 
@@ -80,33 +80,33 @@ Now we describe the steps in the flow.
 
 #### 2. Fulfill the Lock Payment Condition
 
-- The a data scientist listens for the `ExecuteAgreement` on-chain event, in order to `lock the payment` in the `PaymentCondition.sol` smart contract and fulfill the condition.
+- The data scientist listens for the `ExecuteAgreement` on-chain event, in order to `lock the payment` in the `PaymentCondition.sol` smart contract and fulfills the condition.
 
 #### 3. Fulfill the Upload Algorithm Condition
 
 - The data scientist parses the DDO (using Squid) to see how the Publisher exposes a computing service. The computing service defines how to upload an algorithm to the Publisher side and how to consume an output.
 - The data scientist uploads the algorithm _off-chain_ directly to the data set Publisher's algorithm endpoint.
-- Once, the algorithm files are uploaded, the data scientist calculates the files' hash, signs this hash and then submits the signature **ONLY** on-chain.
-- The Publisher receives the algorithm files, calculates the hash (algorithm files) and submits this hash to fulfill the `uploadAlgorithm` condition. The keeper contracts automatically verify that both parties see the same files using 1) the hash which is submitted by the Publisher, 2) the signature submitted by the data scientist and 3) the data scientist address.
+- Once, the algorithm files are uploaded, the data scientist calculates the files' hash, signs this hash and then submits **ONLY** the signature on-chain.
+- The Publisher receives the algorithm files, calculates the hash (algorithm files) and submits this hash to fulfill the `uploadAlgorithm` condition. The Keeper contracts automatically verify that both parties see the same files using 1) the hash which is submitted by the Publisher; 2) the signature submitted by the data scientist; and, 3) the data scientist's address.
 - Please note that the software component that is responsible for running the algorithm, attaching data assets, and running the container is Brizo. Moreover, it pulls the logs periodically and saves the outputs.
 
 #### 4. Fulfill the Grant Access Condition
 
 - Meanwhile, the Publisher starts computation, trains the model, collects logs and generates outputs (the derived assets). Finally, the Publisher archives and uploads the outputs.
-- The Publisher registers the derived assets (outputs) as a DIDs/DDOs and assigns ownership to the data scientist.
+- The Publisher registers the derived assets (outputs) as DIDs/DDOs and assigns ownership to the data scientist.
 - The Publisher grants access to the data scientist using the Secret Store and fulfills the grant access condition.
 
 #### 5. Release Payment
 
 - Once the grant access condition is fulfilled (within a `timeout`), the Publisher can release payment.
-- The data scientist can consume the derived assets (outputs) by calling the Secret Store which in turn checks the permissions on-chain then downloads the outputs using the decryption keys.
+- The data scientist can consume the derived assets (outputs) by calling the Secret Store which in turn checks the permissions on-chain, and then downloads the outputs using the decryption keys.
 
 #### 6. Cancel Payment
 
 The payment can be cancelled only if:
 
-- the access to the derived assets (outputs) was never delivered within timeout, or
-- payment was never locked.
+- The access to the derived assets (outputs) was not delivered within timeout period, or
+- Payment was never locked.
 
 #### 7. Agreement Fulfillment
 
@@ -119,4 +119,4 @@ Some next steps may include:
 * Adding an extra condition for a _proof of computation_ as verifiable proof.
 * Integrating different cloud providers/on-premise infrastructure.
 * Supporting different kinds of containers, allowing for the execution of different kinds of algorithms.
-* Modelling extended Service Agreements supporting richer services.
+* Modelling extended Service Agreements that support richer services.

--- a/doc/architecture/computing-services.md
+++ b/doc/architecture/computing-services.md
@@ -86,7 +86,7 @@ The following describes the steps in the flow.
 
 - The data scientist parses the DDO (using Squid) to see how the Publisher exposes a computing service. The computing service defines how to upload an algorithm to the Publisher side and how to consume an output.
 - The data scientist uploads the algorithm _off-chain_ directly to the data set Publisher's algorithm endpoint.
-- Once, the algorithm files are uploaded, the data scientist calculates the files' hash, signs this hash and then submits **ONLY** the signature on-chain.
+- Once the algorithm files are uploaded, the data scientist calculates the files' hash, signs this hash and then submits **ONLY** the signature on-chain.
 - The Publisher receives the algorithm files, calculates the hash (algorithm files) and submits this hash to fulfill the `uploadAlgorithm` condition. The Keeper contracts automatically verify that both parties see the same files using 1) the hash which is submitted by the Publisher; 2) the signature submitted by the data scientist; and, 3) the data scientist's address.
 - Please note that the software component that is responsible for running the algorithm, attaching data assets, and running the container is Brizo. Moreover, it pulls the logs periodically and saves the outputs.
 

--- a/doc/architecture/computing-services.md
+++ b/doc/architecture/computing-services.md
@@ -1,45 +1,39 @@
 ---
 title: Computing Services
-description: This page describes the highlights of the integration of additional computing services.
+description: How Ocean Protocol enables Publishers to provide computing services and related services.
 slug: /concepts/computing-services/
 section: concepts
 ---
 
 ## Motivation
 
-The most basic scenario of a Publisher, is to provide access to the Assets this Publisher owns or manage.
+The most basic scenario for a Publisher is to provide access to the datasets they own or manage.
+In addition to that, a Publisher could offer other data-related services.
+Some possibilities are:
 
-In addition to this, having this data ecosystem in place, Publishers could offer other related services in top of this. Some possibles scenarios are:
+1. A service to execute some computation on top of their data. This has some benefits:
 
-**1**
+   - The data **never** leaves the Publisher enclave.
+   - It's not necessary to move the data; the algorithm is sent to the data.
+   - Having only one copy of the data and not moving it makes easier to be compliant with data protection regulations.
 
-The Publishers offer as a service the possibility of execute some computation on top of their data. This has some benefits:
-
-- The data **never** leaves the Publisher enclave
-- It's not necessary to move the data, the algorithm moves to the data
-- Data Protection Regulation. Having only the data once and not moving it, makes easier to be compliant to the Data Protection Regulations applying to your data
-
-**2**
-
-Storage services for new derived assets. As a result of the computation of the existing datasets, a new derived dataset could be created. Publishers could offer an additional service to make use of their existing storage capabilities.
-
-This is always optional, being possible to the users using the compute services, to download the new derived datasets created as a result of this computation.
+2. A service to store newly-derived datasets. As a result of the computation on existing datasets, a new dataset could be created. Publishers could offer a storage service to make use of their existing storage capabilities. This is optional; users could also download the newly-derived datasets.
 
 ## Architecture
 
 ### Enabling Publisher Services (Brizo)
 
-The direct interaction with the infrastructure where the data is, requires the execution of a component handled by Publishers.
+The direct interaction with the infrastructure where the data is requires the execution of a component handled by Publishers.
 
-This component will be in charge of interact with the users, and manage the basics of own Publisher infrastructure to provide the additional services.
+This component will be in charge of interacting with users and managing the basics of a Publisher's infrastructure to provide the additional services.
 
-This business logic supporting the some additional Publisher capabilities, is responsibility of a new technical component.
+This business logic supporting the additional Publisher capabilities is the responsibility of this new technical component.
 
-The main & new key component introduced to support new Publisher services is named **Brizo**.
+The main and new key component introduced to support these additional Publisher services is named **Brizo**.
 
 > Brizo is an ancient Greek goddess who was known as the protector of mariners, sailors, and fishermen. She was worshipped primarily by the women of Delos, who set out food offerings in small boats. Brizo was also known as a prophet specializing in the interpretation of dreams.
 
-In the "Ocean ecosystem", Brizo is the technical component executed by the **Publishers** allowing to them to provide extended data services. Brizo, as part of the Publisher ecosystem, includes the credentials to interact with the infrastructure (initially cloud, but could be on-premise).
+In the Ocean ecosystem, Brizo is the technical component executed by the **Publishers**, allowing to them to provide extended data services. Brizo, as part of the Publisher ecosystem, includes the credentials to interact with the infrastructure (initially in cloud providers, but it could be on-premise).
 
 Because of those credentials, the execution of Brizo **SHOULD NOT** be delegated to a third-party.
 
@@ -49,15 +43,15 @@ Because of those credentials, the execution of Brizo **SHOULD NOT** be delegated
 
 ### Responsibilities
 
-The main responsibilities of the software are:
+The main responsibilities of Brizo are:
 
-* Expose a HTTP API allowing to execute some extended data related services (compute and/or storage)
-* Authorize the user on-chain using the proper Service Agreement. It allows to validate that user requesting the service is allowed to use that service.
-* Interact with the infrastructure (cloud/on-premise) using the Publisher credentials.
-* Start/stop/execute computing instances with the algorithm's provided by the users
-* Retrieve the logs generated during the executions
-* Register new Assets derivated of the executions as new Ocean Assets
-* Provide **Proofs of Computation** to the Ocean Network
+* Expose an HTTP API allowing one to execute some extended data-related services (compute and/or storage).
+* Authorize the user on-chain using the proper Service Agreement. That is, validate that user requesting the service is allowed to use that service.
+* Interact with the infrastructure (cloud/on-premise) using the Publisher's credentials.
+* Start/stop/execute computing instances with the algorithms provided by users.
+* Retrieve the logs generated during executions.
+* Register newly-derived assets arising from the executions (as new Ocean assets).
+* Provide **Proofs of Computation** to the Ocean Network.
 
 ### Flow
 
@@ -65,62 +59,64 @@ The main responsibilities of the software are:
 
 In the above diagram you can see the initial integration supported. It involves the following components/actors:
 
-* Data scientists - Final users requiring to use some computing/storage services where the data they are using is.
+* Data scientists - The final users who need to use some computing/storage services offered by the same Publisher as the data Publisher.
 * Ocean Keeper - In charge of enforcing the Service Agreement by tracing conditions.
-* Publisher Infrastrucure - Cloud or On-Premise. Is were the Publisher data is.
-* Publisher Agent (Brizo) - Orchestrate/provides the additional publisher services
-* Publisher - Is the user owning the data and running Brizo. He/she doesn't interact actively in this flow.
+* Publisher Infrastructure - The storage and computing systems where the Publisher's data resides (in a cloud provider or on-premise).
+* Publisher Agent (Brizo) - Orchestrates/provides additional Publisher services.
+* Publisher - The actor running Brizo and other software. The Publisher is often the same as the data owner.
 
-The pre-conditions of this flow are:
+Before the flow can begin, the following pre-conditions must be met:
 
-* The Algorithm is implemented in one of the languages/frameworks supported by the Publisher
-* The Publisher, specified in the Asset DDO the endpoint exposed by the Publisher (Brizo) to expose the computing services.
-* Service Agreement template is already predefined and whitelisted `on-chain`.
+* The Algorithm must be implemented in one of the languages/frameworks supported by the Publisher.
+* The Asset DDO must specify the Brizo endpoint exposed by the Publisher.
+* The Service Agreement template is already predefined and whitelisted `on-chain`.
 
-#### 1. Setup Service Agreement
+Now we describe the steps in the flow.
 
-- The game begins with a data scientist is looking for a data asset but this data is attached to itsown compute service. He/She picks the asset, signs the agreement, then sends `signature, templateId` to the asset publisher.
-- The publisher setup a new service agreement instance `on-chain` using the data scientist (consumer's) signature.
+#### 1. Set Up the Service Agreement
 
-#### 2. Fulfill Lock Payment Condition
+- The game begins with a data scientist looking for a data asset and finding one where the data is attached to its own compute service. They pick the asset, sign the agreement, then send `signature, templateId` to the asset Publisher.
+- The Publisher sets up a new Service Agreement instance on-chain, using the data scientist's signature.
 
-- As a data scientist, he/she listens to `ExecuteAgreement` on-chain event, in order to `lock the payment` in the `PaymentCondition.sol` contract and fulfill the condition.
+#### 2. Fulfill the Lock Payment Condition
 
-#### 3. Fulfill Upload Algorithm Condition
+- The a data scientist listens for the `ExecuteAgreement` on-chain event, in order to `lock the payment` in the `PaymentCondition.sol` smart contract and fulfill the condition.
 
-- The Data scientist, parses the DDO (using Squid) in order to see how the Publisher exposes a computing service. The computing service defines, `how to upload an algorithm to the publisher side`, and `how to consume an output`.
-- The data scientist, uploads the algorithm `off-chain` directly to the data set publisher `algorithm endpoint`.
-- Once, the algorithm file/s is/are uploaded, the data scientist calculates file/s hash, signs this hash and then submits the signature **ONLY** on-chain. 
-- The publisher receives the algorithm file/s, calculates the hash(algorithm file/s) and submits this hash in order to fulfill `uploadAlgorithm` condition. The keeper contracts automatically, verifies that both parties see the same files using (the `hash which is submitted by the publisher`, `signature submitted by data scientist` and `data scientist address`).
-- Please do note that the software component that is responsible for running the algorithm, attaching data assets and runs the container is the [Brizo](https://github.com/oceanprotocol/brizo). Moreover, it pulls the logs periodically and saves the outputs.
+#### 3. Fulfill the Upload Algorithm Condition
 
-#### 4. Fulfill Grant Access Condition
+- The data scientist parses the DDO (using Squid) to see how the Publisher exposes a computing service. The computing service defines how to upload an algorithm to the Publisher side and how to consume an output.
+- The data scientist uploads the algorithm _off-chain_ directly to the data set Publisher's algorithm endpoint.
+- Once, the algorithm files are uploaded, the data scientist calculates the files' hash, signs this hash and then submits the signature **ONLY** on-chain.
+- The Publisher receives the algorithm files, calculates the hash (algorithm files) and submits this hash to fulfill the `uploadAlgorithm` condition. The keeper contracts automatically verify that both parties see the same files using 1) the hash which is submitted by the Publisher, 2) the signature submitted by the data scientist and 3) the data scientist address.
+- Please note that the software component that is responsible for running the algorithm, attaching data assets, and running the container is Brizo. Moreover, it pulls the logs periodically and saves the outputs.
 
-- Meanwhile, the publisher starts computation machine/s, trains the model, collects logs and generates outputs (the derived asset). Finally, The publisher archives and uploads the outputs.
-- The publisher registers the derived asset (outputs) as a DID/DDO and assigns the ownership to the data scientist.
-- The publisher grants access to the data scientist using `secret-store` and fulfill the grant access condition.
+#### 4. Fulfill the Grant Access Condition
 
-#### 5. Fulfill Release Payment
+- Meanwhile, the Publisher starts computation, trains the model, collects logs and generates outputs (the derived assets). Finally, the Publisher archives and uploads the outputs.
+- The Publisher registers the derived assets (outputs) as a DIDs/DDOs and assigns ownership to the data scientist.
+- The Publisher grants access to the data scientist using the Secret Store and fulfills the grant access condition.
 
-- Release Payment as a part of the reward function verifies all the above conditions. and the publisher can call it once the granted access is fulfilled within a `timeout`.
-- The data scientist can consume the derived asset (outputs) by calling the secret store which in turn check the permissions on-chain then downloads the outputs using the decryption keys.
+#### 5. Release Payment
+
+- Once the grant access condition is fulfilled (within a `timeout`), the Publisher can release payment.
+- The data scientist can consume the derived assets (outputs) by calling the Secret Store which in turn checks the permissions on-chain then downloads the outputs using the decryption keys.
 
 #### 6. Cancel Payment
 
 The payment can be cancelled only if:
 
-- The access to the derived asset (outputs) never delivered within timeout.
-- Payment never locked.
+- the access to the derived assets (outputs) was never delivered within timeout, or
+- payment was never locked.
 
-#### 7. Agreement Fulfillement
+#### 7. Agreement Fulfillment
 
-The service agreement will be accepted as fulfilled agreement only if the `payment is released` to the service provider.
+The Service Agreement will be accepted as fulfilled only if the payment is released to the service provider.
 
-## Next steps
+## Next Steps
 
-Next steps are:
+Some next steps may include:
 
-* Adding extra condition for `proof of computation` as verifiable proof
-* Integrate different cloud providers/on-premise infrastructure
-* Support different kind of container flavours allowing to execute different kind of algorithms
-* Model extended service agreements supporting richer services
+* Adding an extra condition for a _proof of computation_ as verifiable proof.
+* Integrating different cloud providers/on-premise infrastructure.
+* Supporting different kinds of containers, allowing for the execution of different kinds of algorithms.
+* Modelling extended Service Agreements supporting richer services.


### PR DESCRIPTION
The `computing-services.md` file in the dev-ocean repo is publicly-readable in the new docs site at https://betadocs.oceanprotocol.com/concepts/computing-services/ so I copy-edited it. (I already edited all the other dev-ocean pages currently rendered on the docs site. This is the last one for now.)

I _didn't_ edit for technical accuracy.

When I wasn't sure if some markup was meaningful, I left it alone.