### PR TITLE
Removed links to C4 and Intellij code coverage

### DIFF
--- a/doc/alm/definition-of-done.md
+++ b/doc/alm/definition-of-done.md
@@ -16,7 +16,7 @@ Before to close a development user story in the board, commonly all the followin
 * Code builds without warnings on **Travis**. Travis is enabled as a validating stage in the Pull Request workflow.
 * Code is unit tested.
 * Documentation is updated.
-* Code Coverage of new code is higher than **70%** (lines covered)
+* Code Coverage of new code is higher than **70%** (lines covered).
 * Code is peer-reviewed (technical task). Because of the [Git setup](../devops/github-setup.md), pull requests can only be merged after approval.
 * After the review, the code is merged to develop branch. ([Gitflow](../development/branching-model.md))
 * Security analysis per component/module is performed, when required. (**To be defined**)
@@ -25,10 +25,3 @@ Before to close a development user story in the board, commonly all the followin
 ## Automation
 
 It's necessary to automate all the previous points as much as possible. This will help us have clean, stable and more secure code.
-
-## Links
-
-* [Collective Code Construction Contract](https://rfc.zeromq.org/spec:42/C4/)
-* [Intellij viewing code coverage](https://www.jetbrains.com/help/idea/viewing-code-coverage-results.html)
-
-


### PR DESCRIPTION
because:

1. this document doesn't reference C4 in any way, and C4 doesn't have a concept of "Definition of Done", and
2. there are many ways to check code coverage and there's no reason for us to be promoting Intellij for that.
