### PR TITLE
Don't mention the current milestones in PROJECT_MAP.md

### DIFF
--- a/PROJECT_MAP.md
+++ b/PROJECT_MAP.md
@@ -14,8 +14,6 @@ A complete description of the Ocean boards can be found in the [Boards section](
 
 See the [Milestones page](https://github.com/oceanprotocol/ocean/milestones).
 
-The current milestone is [Trilobite - Tethys Beta (v0.9)](https://github.com/oceanprotocol/ocean/milestone/2).
-
 ## Main Ocean Development Repositories
 
 See [Docs: Software Components](https://docs.oceanprotocol.com/concepts/components/)


### PR DESCRIPTION
because the `PROJECT_MAP.md` page is a bit buried, so we don't look at it often, so it's easy for it to get out of sync with reality. If someone clicks the already-included link to the [Milestones page](https://github.com/oceanprotocol/ocean/milestones), then they will see all current milestones anyway... and _that_ page is auto-updated by GitHub.