### PR TITLE
Add intro, revise parity.service & config.toml

### DIFF
--- a/doc/devops/keeper-setup.md
+++ b/doc/devops/keeper-setup.md
@@ -124,8 +124,9 @@ hosts = ["all"]
 [mining]
 engine_signer = "<ACCOUNT_ADDRESS>"
 force_sealing = true
-reseal_on_txs = "all"
+reseal_on_txs = "none" // Authorities reseal automatically. From https://bit.ly/2Jiw5SV
 gas_floor_target = "6666666"
+usd_per_tx = "0" // Allows for free transactions. From https://bit.ly/2Jiw5SV
 
 [account]
 password = ["/etc/parity/password"]

--- a/doc/devops/keeper-setup.md
+++ b/doc/devops/keeper-setup.md
@@ -76,7 +76,7 @@ Please note:
 
 - The ports exposed from the container to the host are 30303/tcp (ethereum listener), 30303/udp (ethereum discovery) , 8545 (rpc interface) and 8546 (websocket interface). You can modify the host's ports (the first ports) if you want to modify the exposed ports in the host.
 - The volume /parity_data is the `base_path` folder for the parity client. All the data (chain data, keys, secret store data, etc.) will be stored here. You can change the host's folder (first part) if you want to allocate in a different host location.
-- The volume /etc/parity/ is the configuration folder for the parity client. The parity configuration file (`config.toml`) and the Ocean chain specification (`chain.json`), and the account password (for validators) are located in this folder. Again you can modify the local folder without mahor issue.
+- The volume /etc/parity/ is the configuration folder for the parity client. The parity configuration file (`config.toml`) and the Ocean chain specification (`chain.json`), and the account password (for validators) are located in this folder. Again you can modify the local folder without major issue.
 
 3. Add the Parity configuration file `/etc/parity/config.toml`. To understand the settings, see the [docs about configuring Parity Ethereum](https://wiki.parity.io/Configuring-Parity-Ethereum.html) and the [docs about Parity Proof-of-Authority Chains](https://wiki.parity.io/Proof-of-Authority-Chains).
 

--- a/doc/devops/keeper-setup.md
+++ b/doc/devops/keeper-setup.md
@@ -1,5 +1,13 @@
 # Ocean Parity Installation Guide
 
+## Introduction
+
+This guide started out as a guide to setting up and running a keeper node in the Nile Testnet. Its scope expanded to include other networks, including the Duero Testnet and production networks. Production networks have higher security requirements.
+
+A keeper node is basically a computer running [Parity Ethereum](https://www.parity.io/ethereum/), configured to be part of a particular Ethereum network: one where the Ocean Protocol keeper contracts have been (or will be) deployed.
+
+Parity Ethereum is sometimes called just "Parity." Parity is also the name of the company behind Parity Ethereum, but the context should make it clear what is meant.
+
 ## Requirements
 
 As stated in Parity documentation (https://wiki.parity.io/FAQ#what-are-the-parity-ethereum-disk-space-needs-and-overall-hardware-requirements), the requirements would be:
@@ -30,9 +38,10 @@ We package the stable versions of [Parity Ethereum](https://github.com/oceanprot
 
 The steps to follow are:
 
-1. Install Docker CE. Please check Docker official documentation (link) for a detailed guide.
+1. Install Docker CE. Please check [the Docker official documentation](https://docs.docker.com/install/) for a detailed guide.
 
-2. Configure the Systemd unit:
+2. Configure the systemd unit:
+
 ```bash
 cat <<EOF | sudo tee /etc/systemd/system/parity.service
 [Unit]
@@ -50,10 +59,10 @@ ExecStart=/usr/bin/docker run\
  -p 8545:8545\
  -p 8546:8546/tcp\
  --volume=/parity_data/:/parity_data/\
- --volume=/etc/ocean/:/etc/ocean/\
+ --volume=/etc/parity/:/etc/parity/\
  --entrypoint=/opt/parity/parity\
- oceanprotocol/parity-ethereum:master\
- --config /etc/ocean/config.toml
+ parity/parity:v2.3.3\
+ --config /etc/parity/config.toml
 ExecStop=/usr/bin/docker rm -f %N
 
 [Install]
@@ -64,32 +73,48 @@ sudo chmod 644 /etc/systemd/system/parity.service
 ```
 
 Please note:
+
 - The ports exposed from the container to the host are 30303/tcp (ethereum listener), 30303/udp (ethereum discovery) , 8545 (rpc interface) and 8546 (websocket interface). You can modify the host's ports (the first ports) if you want to modify the exposed ports in the host.
 - The volume /parity_data is the `base_path` folder for the parity client. All the data (chain data, keys, secret store data, etc.) will be stored here. You can change the host's folder (first part) if you want to allocate in a different host location.
-- The volume /etc/ocean is the configuration folder for the parity client. The parity configuration file (`config.toml`) and the Ocean chain specification (`chain.json`), and the account password (for validators) are located in this folder. Again you can modify the local folder without mahor issue.
+- The volume /etc/parity/ is the configuration folder for the parity client. The parity configuration file (`config.toml`) and the Ocean chain specification (`chain.json`), and the account password (for validators) are located in this folder. Again you can modify the local folder without mahor issue.
 
-3. Add the parity configuration:
+3. Add the Parity configuration file `/etc/parity/config.toml`. To understand the settings, see [the docs about configuring Parity Ethereum](https://wiki.parity.io/Configuring-Parity-Ethereum.html).
+
 ```bash
 [parity]
-chain = "/etc/ocean/chain.json"
+chain = "/etc/parity/chain.json"
 base_path = "/parity_data"
 no_persistent_txqueue = true
 
-[ui]
-disable = true
-
 [rpc]
-disable = true
+disable = false
+port = 8545
 interface = "all"
 cors = ["all"]
 hosts = ["all"]
 apis = ["all"]
 
+[secretstore]
+disable = true
+
+[network]
+nat = "extip:<PUBLIC_IP"
+port = 30303
+reserved_peers = "/etc/parity/peers"
+node_key = "<ETHEREUM_NODE_KEY>"
+discovery = true
+
+[ui]
+disable = true
+
 [ipc]
 disable = true
 
-[websockets]
+[dapps]
 disable = true
+
+[websockets]
+disable = false
 port = 8546
 interface = "all"
 origins = ["all"]
@@ -98,36 +123,27 @@ hosts = ["all"]
 
 [mining]
 engine_signer = "<ACCOUNT_ADDRESS>"
-reseal_on_txs = "none"
-usd_per_tx = "0"
-gas_floor_target = "4700000"
-
-[network]
-nat = "extip:<PUBLIC_IP>"
-port = 30303
-node_key = "<ETHEREUM_NODE_KEY>"
-discovery = true
-
-[ipfs]
-enable = false
-
-[snapshots]
-disable_periodic = true
+force_sealing = true
+reseal_on_txs = "all"
+gas_floor_target = "6666666"
 
 [account]
-password = ["/etc/ocean/password"]
+password = ["/etc/parity/password"]
 
-[secretstore]
-disable = true
+[footprint]
+tracing = "on"
+pruning = "archive"
+fat_db = "on"
 ```
 
 Where:
-- ACCOUNT_ADDRESS: This is the ethereum address where you want to mine. Please put here your authority account if you have one.
-- PUBLIC_IP: The external public IP of your node.
-- ETHEREUM_NODE_KEY: The Ethereum node address
-- The file `/etc/ocean/password` contains the account's password. You can change the location of this file, but take care that this location reffers to a location inside the parity container, so you have to refer to the container location and mount the host's file to that location.
 
-4. Get the chain file for the network you're joining and save it in `/etc/ocean/chain.json`. Here are some links to chain files:
+- ACCOUNT_ADDRESS: Please put here your authority account address if you have one. Example: `0xdeadbeefcafe0000000000000000000000000001`
+- PUBLIC_IP: The external public IP address of your node. Example: `52.1.94.55`
+- ETHEREUM_NODE_KEY: The Ethereum node address. Example: `ade848e26c30d600da8207d0f8960d6abf125d1ac432bd42b020a98e10812f36`
+- The file `/etc/parity/password` contains the account's password. You can change the location of this file, but take care that this location refers to a location inside the parity container, so you have to refer to the container location and mount the host's file to that location.
+
+4. Get the chain file for the network you're joining and save it in `/etc/parity/chain.json`. Here are some links to chain files:
 
    - [Nile chain file](https://github.com/oceanprotocol/atlantic/blob/master/networks/nile/chain.json)
    - [Duero chain file](https://github.com/oceanprotocol/atlantic/blob/master/networks/duero/chain.json)

--- a/doc/devops/keeper-setup.md
+++ b/doc/devops/keeper-setup.md
@@ -4,9 +4,9 @@
 
 This guide started out as a guide to setting up and running a keeper node in the Nile Testnet. Its scope expanded to include other networks, including the Duero Testnet and production networks. Production networks have higher security requirements.
 
-A keeper node is basically a computer running [Parity Ethereum](https://www.parity.io/ethereum/), configured to be part of a particular Ethereum network: one where the Ocean Protocol keeper contracts have been (or will be) deployed.
+A keeper node is basically a computer running [Parity Ethereum](https://www.parity.io/ethereum/), configured to be part of a particular Ethereum network: one where the Ocean Protocol keeper contracts have been (or will be) deployed. In particular, this guide is about how to set up an _authority node_ (not a user node, not a secret store node) in a ]Parity Proof of Authority (PoA) network](https://wiki.parity.io/Proof-of-Authority-Chains).
 
-Parity Ethereum is sometimes called just "Parity." Parity is also the name of the company behind Parity Ethereum, but the context should make it clear what is meant.
+Note: Parity Ethereum is sometimes called just "Parity." Parity is also the name of the company behind Parity Ethereum, but the context should make it clear what is meant.
 
 ## Requirements
 
@@ -78,7 +78,7 @@ Please note:
 - The volume /parity_data is the `base_path` folder for the parity client. All the data (chain data, keys, secret store data, etc.) will be stored here. You can change the host's folder (first part) if you want to allocate in a different host location.
 - The volume /etc/parity/ is the configuration folder for the parity client. The parity configuration file (`config.toml`) and the Ocean chain specification (`chain.json`), and the account password (for validators) are located in this folder. Again you can modify the local folder without mahor issue.
 
-3. Add the Parity configuration file `/etc/parity/config.toml`. To understand the settings, see [the docs about configuring Parity Ethereum](https://wiki.parity.io/Configuring-Parity-Ethereum.html).
+3. Add the Parity configuration file `/etc/parity/config.toml`. To understand the settings, see the [docs about configuring Parity Ethereum](https://wiki.parity.io/Configuring-Parity-Ethereum.html) and the [docs about Parity Proof-of-Authority Chains](https://wiki.parity.io/Proof-of-Authority-Chains).
 
 ```bash
 [parity]

--- a/doc/devops/keeper-setup.md
+++ b/doc/devops/keeper-setup.md
@@ -4,7 +4,7 @@
 
 This guide started out as a guide to setting up and running a keeper node in the Nile Testnet. Its scope expanded to include other networks, including the Duero Testnet and production networks. Production networks have higher security requirements.
 
-A keeper node is basically a computer running [Parity Ethereum](https://www.parity.io/ethereum/), configured to be part of a particular Ethereum network: one where the Ocean Protocol keeper contracts have been (or will be) deployed. In particular, this guide is about how to set up an _authority node_ (not a user node, not a secret store node) in a ]Parity Proof of Authority (PoA) network](https://wiki.parity.io/Proof-of-Authority-Chains).
+A keeper node is basically a computer running [Parity Ethereum](https://www.parity.io/ethereum/), configured to be part of a particular Ethereum network: one where the Ocean Protocol keeper contracts have been (or will be) deployed. In particular, this guide is about how to set up an _authority node_ (not a user node, not a secret store node) in a [Parity Proof of Authority (PoA) network](https://wiki.parity.io/Proof-of-Authority-Chains).
 
 Note: Parity Ethereum is sometimes called just "Parity." Parity is also the name of the company behind Parity Ethereum, but the context should make it clear what is meant.
 


### PR DESCRIPTION
This pull request does three main things in the **Ocean Parity Installation Guide**

1. Add an Introduction section
1. Revise `/etc/systemd/system/parity.service`
   - switch from `oceanprotocol/parity-ethereum:master` to `parity/parity:v2.3.3`
   - switch from using `/etc/ocean/` to using `/etc/parity/` (not just there but everywhere)
1. Revise the example `config.toml` file. I did my best to synthesize something consistent with all the sources I was given. I gave some example values.

I also added links to the docs about Docker CE and Parith Ethereum configuration.